### PR TITLE
Persist AI toolkit sessions in server demos

### DIFF
--- a/src/app/ai-agent-chatbot/page.tsx
+++ b/src/app/ai-agent-chatbot/page.tsx
@@ -69,4 +69,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/api/server-ai-agent-chatbot/route.ts
+++ b/src/app/api/server-ai-agent-chatbot/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -13,6 +12,10 @@ import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getDocument } from "@/lib/server-ai-toolkit/get-document";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 import { updateDocument } from "@/lib/server-ai-toolkit/update-document";
 
 const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
@@ -38,10 +41,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
 
   // Get tool definitions from the Server AI Toolkit API
   const toolDefinitions = await getToolDefinitions({
@@ -69,7 +73,9 @@ export async function POST(req: Request) {
               input,
               document,
               schemaAwarenessData,
+              { sessionId },
             );
+            sessionId = result.sessionId;
 
             // Update the document after executing the tool if it changed
             if (result.docChanged && result.document && documentId) {
@@ -109,6 +115,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-ai-tracked-changes-comments/route.ts
+++ b/src/app/api/server-ai-tracked-changes-comments/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -12,6 +11,10 @@ import { getIp, rateLimit } from "@/lib/rate-limit";
 import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 
 export async function POST(req: Request) {
   if (process.env.UPSTASH_REDIS_REST_URL) {
@@ -33,10 +36,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
   const toolDefinitions = await getToolDefinitions({
     schemaAwarenessData,
     operationMeta:
@@ -60,6 +64,7 @@ export async function POST(req: Request) {
               schemaAwarenessData,
               {
                 documentId,
+                sessionId,
                 userId: "ai-assistant",
                 reviewOptions: {
                   mode: "trackedChanges",
@@ -70,6 +75,7 @@ export async function POST(req: Request) {
                 },
               },
             );
+            sessionId = result.sessionId;
 
             return result.output;
           } catch (error) {
@@ -108,6 +114,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-ai-tracked-changes/route.ts
+++ b/src/app/api/server-ai-tracked-changes/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -12,6 +11,10 @@ import { getIp, rateLimit } from "@/lib/rate-limit";
 import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 
 export async function POST(req: Request) {
   if (process.env.UPSTASH_REDIS_REST_URL) {
@@ -33,10 +36,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
   const toolDefinitions = await getToolDefinitions({
     schemaAwarenessData,
   });
@@ -58,12 +62,14 @@ export async function POST(req: Request) {
               schemaAwarenessData,
               {
                 documentId,
+                sessionId,
                 userId: "ai-assistant",
                 reviewOptions: {
                   mode: "trackedChanges",
                 },
               },
             );
+            sessionId = result.sessionId;
 
             return result.output;
           } catch (error) {
@@ -100,6 +106,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-comments/route.ts
+++ b/src/app/api/server-comments/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -13,6 +12,10 @@ import { executeCommentsTool } from "@/lib/server-ai-toolkit/execute-comments-to
 import { getCommentsToolDefinitions } from "@/lib/server-ai-toolkit/get-comments-tool-definitions";
 import { getDocument } from "@/lib/server-ai-toolkit/get-document";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 import { updateDocument } from "@/lib/server-ai-toolkit/update-document";
 
 const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
@@ -38,10 +41,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
 
   const tiptapCloudDocumentServerId =
     process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID;
@@ -61,6 +65,7 @@ export async function POST(req: Request) {
     apiSecret: documentManagementApiSecret,
     userId: "ai-assistant",
     appId: tiptapCloudDocumentServerId,
+    sessionId,
   };
 
   // Get tool definitions from the Server AI Toolkit API (with comments tools)
@@ -87,8 +92,12 @@ export async function POST(req: Request) {
               input,
               document,
               schemaAwarenessData,
-              commentsOptions,
+              {
+                ...commentsOptions,
+                sessionId,
+              },
             );
+            sessionId = result.sessionId;
 
             // Update the document after executing the tool if it changed
             if (result.docChanged && result.document && documentId) {
@@ -129,6 +138,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/comments-workflow/page.tsx
+++ b/src/app/comments-workflow/page.tsx
@@ -317,4 +317,3 @@ export default function Page() {
     </ThreadsProvider>
   );
 }
-

--- a/src/app/comments/page.tsx
+++ b/src/app/comments/page.tsx
@@ -6,4 +6,3 @@ import "../../demos/comments/style.scss";
 export default function Page() {
   return <Comments />;
 }
-

--- a/src/app/insert-content-workflow/page.tsx
+++ b/src/app/insert-content-workflow/page.tsx
@@ -118,4 +118,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/justified-changes/page.tsx
+++ b/src/app/justified-changes/page.tsx
@@ -237,4 +237,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/multi-document/page.tsx
+++ b/src/app/multi-document/page.tsx
@@ -289,4 +289,3 @@ function EditorComponent({
     />
   );
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -265,9 +265,14 @@ export default function Home() {
         </div>
 
         <div className="mt-14 text-center text-xs text-gray-300">
-          Set <code className="bg-gray-50 px-1.5 py-0.5 rounded text-gray-400">OPENAI_API_KEY</code>{" "}
+          Set{" "}
+          <code className="bg-gray-50 px-1.5 py-0.5 rounded text-gray-400">
+            OPENAI_API_KEY
+          </code>{" "}
           and{" "}
-          <code className="bg-gray-50 px-1.5 py-0.5 rounded text-gray-400">ANTHROPIC_API_KEY</code>{" "}
+          <code className="bg-gray-50 px-1.5 py-0.5 rounded text-gray-400">
+            ANTHROPIC_API_KEY
+          </code>{" "}
           environment variables to use these demos.
         </div>
       </div>

--- a/src/app/preview-changes-streaming/page.tsx
+++ b/src/app/preview-changes-streaming/page.tsx
@@ -261,4 +261,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/preview-changes/page.tsx
+++ b/src/app/preview-changes/page.tsx
@@ -228,4 +228,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/proofreader/page.tsx
+++ b/src/app/proofreader/page.tsx
@@ -192,4 +192,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/review-changes-streaming/page.tsx
+++ b/src/app/review-changes-streaming/page.tsx
@@ -261,4 +261,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/review-changes/page.tsx
+++ b/src/app/review-changes/page.tsx
@@ -228,4 +228,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/schema-awareness/page.tsx
+++ b/src/app/schema-awareness/page.tsx
@@ -191,4 +191,3 @@ Make sure each alert contains relevant, helpful information that enhances the do
     </div>
   );
 }
-

--- a/src/app/selection-awareness/page.tsx
+++ b/src/app/selection-awareness/page.tsx
@@ -73,4 +73,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/server-ai-agent-chatbot/page.tsx
+++ b/src/app/server-ai-agent-chatbot/page.tsx
@@ -121,4 +121,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/server-ai-tracked-changes-comments/page.tsx
+++ b/src/app/server-ai-tracked-changes-comments/page.tsx
@@ -378,7 +378,7 @@ function TrackedChangesCommentsEditor({
   if (!editor) {
     return null;
   }
-  console.log(threads)
+  console.log(threads);
 
   return (
     <ThreadsProvider
@@ -489,4 +489,3 @@ function TrackedChangesCommentsEditor({
     </ThreadsProvider>
   );
 }
-

--- a/src/app/server-ai-tracked-changes/page.tsx
+++ b/src/app/server-ai-tracked-changes/page.tsx
@@ -254,4 +254,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/server-comments/page.tsx
+++ b/src/app/server-comments/page.tsx
@@ -326,4 +326,3 @@ export default function Page() {
     </ThreadsProvider>
   );
 }
-

--- a/src/app/split-view/page.tsx
+++ b/src/app/split-view/page.tsx
@@ -201,11 +201,17 @@ export default function Page() {
       const padding = 8;
 
       let top = rect.bottom + 4;
-      let left = rect.left + (rect.width / 2) - (popoverWidth / 2);
+      let left = rect.left + rect.width / 2 - popoverWidth / 2;
 
       // Clamp to viewport bounds
-      left = Math.max(padding, Math.min(left, window.innerWidth - popoverWidth - padding));
-      top = Math.max(padding, Math.min(top, window.innerHeight - popoverHeight - padding));
+      left = Math.max(
+        padding,
+        Math.min(left, window.innerWidth - popoverWidth - padding),
+      );
+      top = Math.max(
+        padding,
+        Math.min(top, window.innerHeight - popoverHeight - padding),
+      );
 
       setPopover({ diffId, top, left });
     };
@@ -372,7 +378,9 @@ export default function Page() {
         {/* Top bar when chat is closed: review toolbar + chat toggle */}
         {!isChatOpen && (
           <div className="flex items-center justify-center border-b border-slate-200 px-4 py-2 bg-white flex-shrink-0">
-            {reviewToolbar && <div className="flex-1 flex justify-center">{reviewToolbar}</div>}
+            {reviewToolbar && (
+              <div className="flex-1 flex justify-center">{reviewToolbar}</div>
+            )}
             <button
               type="button"
               onClick={() => setIsChatOpen(true)}
@@ -493,4 +501,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/template-workflow/page.tsx
+++ b/src/app/template-workflow/page.tsx
@@ -219,4 +219,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/tiptap-edit-workflow/page.tsx
+++ b/src/app/tiptap-edit-workflow/page.tsx
@@ -100,4 +100,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/tool-streaming/page.tsx
+++ b/src/app/tool-streaming/page.tsx
@@ -109,4 +109,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/app/tracked-changes-comments/page.tsx
+++ b/src/app/tracked-changes-comments/page.tsx
@@ -429,4 +429,3 @@ export default function Page() {
     </ThreadsProvider>
   );
 }
-

--- a/src/app/tracked-changes/page.tsx
+++ b/src/app/tracked-changes/page.tsx
@@ -211,4 +211,3 @@ export default function Page() {
     </div>
   );
 }
-

--- a/src/lib/server-ai-toolkit/execute-comments-tool.ts
+++ b/src/lib/server-ai-toolkit/execute-comments-tool.ts
@@ -11,7 +11,12 @@ export async function executeCommentsTool(
   _document: unknown,
   schemaAwarenessData: unknown,
   commentsOptions: CommentsOptions,
-): Promise<{ output: unknown; docChanged: boolean; document?: unknown }> {
+): Promise<{
+  output: unknown;
+  docChanged: boolean;
+  document?: unknown;
+  sessionId: string;
+}> {
   const apiBaseUrl =
     process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev/v3/ai";
   const appId = process.env.TIPTAP_CLOUD_AI_APP_ID;
@@ -34,6 +39,7 @@ export async function executeCommentsTool(
       input,
       // document,
       schemaAwarenessData,
+      sessionId: commentsOptions.sessionId,
       experimental_documentOptions: {
         documentId: commentsOptions.documentId,
         userId: commentsOptions.userId,

--- a/src/lib/server-ai-toolkit/execute-tool.ts
+++ b/src/lib/server-ai-toolkit/execute-tool.ts
@@ -3,6 +3,7 @@ import { getTiptapCloudAiJwtToken } from "./get-tiptap-cloud-ai-jwt-token";
 export interface ExecuteToolOptions {
   documentId?: string;
   userId?: string;
+  sessionId?: string;
   reviewOptions?: {
     mode?: "disabled" | "trackedChanges";
   };
@@ -21,7 +22,12 @@ export async function executeTool(
   document: unknown,
   schemaAwarenessData: unknown,
   options: ExecuteToolOptions = {},
-): Promise<{ output: unknown; docChanged: boolean; document?: unknown }> {
+): Promise<{
+  output: unknown;
+  docChanged: boolean;
+  document?: unknown;
+  sessionId: string;
+}> {
   const apiBaseUrl =
     process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev/v3/ai";
   const appId = process.env.TIPTAP_CLOUD_AI_APP_ID;
@@ -43,6 +49,7 @@ export async function executeTool(
       toolName,
       input,
       schemaAwarenessData,
+      sessionId: options.sessionId,
       ...(options.documentId
         ? {
             experimental_documentOptions: {

--- a/src/lib/server-ai-toolkit/get-comments-tool-definitions.ts
+++ b/src/lib/server-ai-toolkit/get-comments-tool-definitions.ts
@@ -6,6 +6,7 @@ export interface CommentsOptions {
   apiSecret: string;
   userId: string;
   appId: string;
+  sessionId?: string;
 }
 
 /**

--- a/src/lib/server-ai-toolkit/session-id.ts
+++ b/src/lib/server-ai-toolkit/session-id.ts
@@ -1,0 +1,21 @@
+import type { UIMessage } from "ai";
+
+export interface ServerAiToolkitMessageMetadata {
+  sessionId?: string;
+}
+
+export type ServerAiToolkitMessage = UIMessage<ServerAiToolkitMessageMetadata>;
+
+export function getSessionIdFromConversationHistory(
+  messages: ServerAiToolkitMessage[],
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const sessionId = messages[index]?.metadata?.sessionId;
+
+    if (typeof sessionId === "string" && sessionId.length > 0) {
+      return sessionId;
+    }
+  }
+
+  return undefined;
+}

--- a/src/styles/split-view.css
+++ b/src/styles/split-view.css
@@ -28,7 +28,7 @@
 .split-view-demo .split-diff-spacer {
   background-color: rgba(244, 244, 245, 0.6);
   border-radius: 6px;
-  cursor: pointer !important;
+  cursor: pointer;
   transition: background-color 0.15s ease;
 }
 


### PR DESCRIPTION
## Summary
- persist the AI server `sessionId` across server-side demo chat turns by reading it from prior assistant message metadata
- pass the resolved `sessionId` through the shared server AI toolkit wrappers so follow-up tool calls reuse the same Redis-backed session
- fix and format the outstanding Biome issues in the demos worktree, including the split-view cursor override

## Validation
- `pnpm lint`
- `pnpm build`
- browser-tested `http://localhost:3000/server-ai-agent-chatbot` against a local AI server + Redis stack
- verified Redis kept a single `ai-toolkit:session:*` key across two chat turns, confirming session reuse