### PR TITLE
Remove tracked changes debug log

### DIFF
--- a/src/app/server-ai-tracked-changes-comments/page.tsx
+++ b/src/app/server-ai-tracked-changes-comments/page.tsx
@@ -378,7 +378,6 @@ function TrackedChangesCommentsEditor({
   if (!editor) {
     return null;
   }
-  console.log(threads)
 
   return (
     <ThreadsProvider


### PR DESCRIPTION
This change removes a leftover `console.log(threads)` call from the tracked changes comments demo page.

The log was only useful during local debugging and causes unnecessary noise in the browser console when using the demo. Removing it keeps the demo output clean without changing behavior.