### PR TITLE
Persist Server AI Toolkit sessions in demos

### DIFF
--- a/src/app/api/server-ai-agent-chatbot/route.ts
+++ b/src/app/api/server-ai-agent-chatbot/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -13,6 +12,10 @@ import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getDocument } from "@/lib/server-ai-toolkit/get-document";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 import { updateDocument } from "@/lib/server-ai-toolkit/update-document";
 
 const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
@@ -38,10 +41,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
 
   // Get tool definitions from the Server AI Toolkit API
   const toolDefinitions = await getToolDefinitions({
@@ -69,7 +73,9 @@ export async function POST(req: Request) {
               input,
               document,
               schemaAwarenessData,
+              { sessionId },
             );
+            sessionId = result.sessionId;
 
             // Update the document after executing the tool if it changed
             if (result.docChanged && result.document && documentId) {
@@ -109,6 +115,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-ai-tracked-changes-comments/route.ts
+++ b/src/app/api/server-ai-tracked-changes-comments/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -12,6 +11,10 @@ import { getIp, rateLimit } from "@/lib/rate-limit";
 import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 
 export async function POST(req: Request) {
   if (process.env.UPSTASH_REDIS_REST_URL) {
@@ -33,10 +36,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
   const toolDefinitions = await getToolDefinitions({
     schemaAwarenessData,
     operationMeta:
@@ -60,6 +64,7 @@ export async function POST(req: Request) {
               schemaAwarenessData,
               {
                 documentId,
+                sessionId,
                 userId: "ai-assistant",
                 reviewOptions: {
                   mode: "trackedChanges",
@@ -70,6 +75,7 @@ export async function POST(req: Request) {
                 },
               },
             );
+            sessionId = result.sessionId;
 
             return result.output;
           } catch (error) {
@@ -108,6 +114,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-ai-tracked-changes/route.ts
+++ b/src/app/api/server-ai-tracked-changes/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -12,6 +11,10 @@ import { getIp, rateLimit } from "@/lib/rate-limit";
 import { executeTool } from "@/lib/server-ai-toolkit/execute-tool";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
 import { getToolDefinitions } from "@/lib/server-ai-toolkit/get-tool-definitions";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 
 export async function POST(req: Request) {
   if (process.env.UPSTASH_REDIS_REST_URL) {
@@ -33,10 +36,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
   const toolDefinitions = await getToolDefinitions({
     schemaAwarenessData,
   });
@@ -58,12 +62,14 @@ export async function POST(req: Request) {
               schemaAwarenessData,
               {
                 documentId,
+                sessionId,
                 userId: "ai-assistant",
                 reviewOptions: {
                   mode: "trackedChanges",
                 },
               },
             );
+            sessionId = result.sessionId;
 
             return result.output;
           } catch (error) {
@@ -100,6 +106,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/api/server-comments-workflow/route.ts
+++ b/src/app/api/server-comments-workflow/route.ts
@@ -30,15 +30,18 @@ export async function POST(req: Request) {
     documentId,
     schemaAwarenessData,
     task,
+    sessionId,
   }: {
     documentId: string;
     schemaAwarenessData: unknown;
     task: string;
+    sessionId?: string | null;
   } = await req.json();
 
   const [documentReadResult, threadsReadResult] = await Promise.all([
     readWorkflowDocument({
       schemaAwarenessData,
+      sessionId,
       format: "shorthand",
       reviewOptions: {
         mode: "disabled",
@@ -105,6 +108,7 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     format: "shorthand",
     input: output,
+    sessionId: documentReadResult.sessionId,
     experimental_documentOptions: {
       documentId,
       userId: "ai-assistant",
@@ -116,6 +120,7 @@ export async function POST(req: Request) {
   });
 
   return Response.json({
+    sessionId: executeResult.sessionId,
     operations: executeResult.output.operations ?? [],
   });
 }

--- a/src/app/api/server-comments/route.ts
+++ b/src/app/api/server-comments/route.ts
@@ -4,7 +4,6 @@ import {
   createAgentUIStreamResponse,
   ToolLoopAgent,
   tool,
-  type UIMessage,
   wrapLanguageModel,
 } from "ai";
 import z from "zod";
@@ -13,6 +12,10 @@ import { executeCommentsTool } from "@/lib/server-ai-toolkit/execute-comments-to
 import { getCommentsToolDefinitions } from "@/lib/server-ai-toolkit/get-comments-tool-definitions";
 import { getDocument } from "@/lib/server-ai-toolkit/get-document";
 import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  getSessionIdFromConversationHistory,
+  type ServerAiToolkitMessage,
+} from "@/lib/server-ai-toolkit/session-id";
 import { updateDocument } from "@/lib/server-ai-toolkit/update-document";
 
 const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
@@ -38,10 +41,11 @@ export async function POST(req: Request) {
     schemaAwarenessData,
     documentId,
   }: {
-    messages: UIMessage[];
+    messages: ServerAiToolkitMessage[];
     schemaAwarenessData: unknown;
     documentId: string;
   } = await req.json();
+  let sessionId = getSessionIdFromConversationHistory(messages);
 
   const tiptapCloudDocumentServerId =
     process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID;
@@ -61,6 +65,7 @@ export async function POST(req: Request) {
     apiSecret: documentManagementApiSecret,
     userId: "ai-assistant",
     appId: tiptapCloudDocumentServerId,
+    sessionId,
   };
 
   // Get tool definitions from the Server AI Toolkit API (with comments tools)
@@ -87,8 +92,12 @@ export async function POST(req: Request) {
               input,
               document,
               schemaAwarenessData,
-              commentsOptions,
+              {
+                ...commentsOptions,
+                sessionId,
+              },
             );
+            sessionId = result.sessionId;
 
             // Update the document after executing the tool if it changed
             if (result.docChanged && result.document && documentId) {
@@ -129,6 +138,8 @@ ${schemaAwarenessPrompt}`,
 
   return createAgentUIStreamResponse({
     agent,
+    messageMetadata: ({ part }) =>
+      part.type === "finish" && sessionId ? { sessionId } : undefined,
     uiMessages: messages,
   });
 }

--- a/src/app/server-comments-workflow/page.tsx
+++ b/src/app/server-comments-workflow/page.tsx
@@ -41,6 +41,7 @@ export default function Page() {
     "Add short, example comments suggesting improvements to sentences in this document",
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [resultMessage, setResultMessage] = useState("");
   // biome-ignore lint/suspicious/noExplicitAny: Interop with js files
   const threadsRef = useRef<any[]>([]);
@@ -209,6 +210,7 @@ export default function Page() {
           documentId,
           schemaAwarenessData: getSchemaAwarenessData(editor),
           task,
+          sessionId,
         }),
       });
 
@@ -217,9 +219,11 @@ export default function Page() {
       }
 
       const result: {
+        sessionId: string;
         operations: Array<{ success: boolean }>;
       } = await response.json();
 
+      setSessionId(result.sessionId);
       setResultMessage(
         `Applied ${result.operations.filter((operation) => operation.success).length} comment operation(s)`,
       );

--- a/src/lib/server-ai-toolkit/execute-comments-tool.ts
+++ b/src/lib/server-ai-toolkit/execute-comments-tool.ts
@@ -11,7 +11,12 @@ export async function executeCommentsTool(
   _document: unknown,
   schemaAwarenessData: unknown,
   commentsOptions: CommentsOptions,
-): Promise<{ output: unknown; docChanged: boolean; document?: unknown }> {
+): Promise<{
+  output: unknown;
+  docChanged: boolean;
+  document?: unknown;
+  sessionId: string;
+}> {
   const apiBaseUrl =
     process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev/v3/ai";
   const appId = process.env.TIPTAP_CLOUD_AI_APP_ID;
@@ -34,6 +39,7 @@ export async function executeCommentsTool(
       input,
       // document,
       schemaAwarenessData,
+      sessionId: commentsOptions.sessionId,
       experimental_documentOptions: {
         documentId: commentsOptions.documentId,
         userId: commentsOptions.userId,

--- a/src/lib/server-ai-toolkit/execute-tool.ts
+++ b/src/lib/server-ai-toolkit/execute-tool.ts
@@ -3,6 +3,7 @@ import { getTiptapCloudAiJwtToken } from "./get-tiptap-cloud-ai-jwt-token";
 export interface ExecuteToolOptions {
   documentId?: string;
   userId?: string;
+  sessionId?: string;
   reviewOptions?: {
     mode?: "disabled" | "trackedChanges";
   };
@@ -21,7 +22,12 @@ export async function executeTool(
   document: unknown,
   schemaAwarenessData: unknown,
   options: ExecuteToolOptions = {},
-): Promise<{ output: unknown; docChanged: boolean; document?: unknown }> {
+): Promise<{
+  output: unknown;
+  docChanged: boolean;
+  document?: unknown;
+  sessionId: string;
+}> {
   const apiBaseUrl =
     process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev/v3/ai";
   const appId = process.env.TIPTAP_CLOUD_AI_APP_ID;
@@ -43,6 +49,7 @@ export async function executeTool(
       toolName,
       input,
       schemaAwarenessData,
+      sessionId: options.sessionId,
       ...(options.documentId
         ? {
             experimental_documentOptions: {

--- a/src/lib/server-ai-toolkit/get-comments-tool-definitions.ts
+++ b/src/lib/server-ai-toolkit/get-comments-tool-definitions.ts
@@ -6,6 +6,7 @@ export interface CommentsOptions {
   apiSecret: string;
   userId: string;
   appId: string;
+  sessionId?: string;
 }
 
 /**

--- a/src/lib/server-ai-toolkit/session-id.ts
+++ b/src/lib/server-ai-toolkit/session-id.ts
@@ -1,0 +1,21 @@
+import type { UIMessage } from "ai";
+
+export interface ServerAiToolkitMessageMetadata {
+  sessionId?: string;
+}
+
+export type ServerAiToolkitMessage = UIMessage<ServerAiToolkitMessageMetadata>;
+
+export function getSessionIdFromConversationHistory(
+  messages: ServerAiToolkitMessage[],
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const sessionId = messages[index]?.metadata?.sessionId;
+
+    if (typeof sessionId === "string" && sessionId.length > 0) {
+      return sessionId;
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/server-ai-toolkit/workflow-api.ts
+++ b/src/lib/server-ai-toolkit/workflow-api.ts
@@ -253,6 +253,7 @@ export async function executeWorkflowThreads(input: {
   schemaAwarenessData: unknown;
   format: WorkflowFormat;
   input: unknown;
+  sessionId?: string | null;
   experimental_documentOptions: {
     documentId: string;
     userId?: string | null;
@@ -263,6 +264,7 @@ export async function executeWorkflowThreads(input: {
   };
 }) {
   return postWorkflowRequest<{
+    sessionId: string;
     output: {
       operations?: Array<{
         type: string;


### PR DESCRIPTION
## Summary
- persist the Server AI Toolkit session across server-side agent chat turns by storing the returned  in assistant message metadata
- pass the active  through the shared execute helpers so follow-up tool calls and the server comments workflow reuse the same stale-read protection
- keep the comments workflow client in sync by storing the returned  between runs

## Validation
- Checked 11 files in 27ms. No fixes applied.
- 
> ai-toolkit-demos@0.1.0 build /Users/arnaugomez/work/sessions/ai-toolkit-session-mechanism/worktrees/ai-toolkit-demos--fix-session-mechanism-pr45
> next build --turbopack

▲ Next.js 16.2.1 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 3.2s
  Running TypeScript ...
  Finished TypeScript in 2.0s ...
  Collecting page data using 10 workers ...
  Generating static pages using 10 workers (0/56) ...
  Generating static pages using 10 workers (14/56) 
  Generating static pages using 10 workers (28/56) 
  Generating static pages using 10 workers (42/56) 
✓ Generating static pages using 10 workers (56/56) in 255ms
  Finalizing page optimization ...

Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /ai-agent-chatbot
├ ƒ /api/chat
├ ƒ /api/comments
├ ƒ /api/comments-workflow
├ ƒ /api/insert-content-workflow
├ ƒ /api/justified-changes
├ ƒ /api/multi-document
├ ƒ /api/proofreader
├ ƒ /api/schema-awareness
├ ƒ /api/selection-awareness
├ ƒ /api/server-ai-agent-chatbot
├ ƒ /api/server-ai-tracked-changes
├ ƒ /api/server-ai-tracked-changes-comments
├ ƒ /api/server-comments
├ ƒ /api/server-comments-workflow
├ ƒ /api/server-edit-workflow
├ ƒ /api/server-insert-content-workflow
├ ƒ /api/server-proofreader-workflow
├ ƒ /api/server-selection-awareness
├ ƒ /api/split-view
├ ƒ /api/template-workflow
├ ƒ /api/tiptap-edit-workflow
├ ƒ /api/tool-streaming
├ ƒ /api/tracked-changes
├ ƒ /api/tracked-changes-comments
├ ○ /comments
├ ○ /comments-workflow
├ ○ /insert-content-workflow
├ ○ /justified-changes
├ ○ /multi-document
├ ○ /preview-changes
├ ○ /preview-changes-streaming
├ ○ /proofreader
├ ○ /review-changes
├ ○ /review-changes-streaming
├ ○ /schema-awareness
├ ○ /selection-awareness
├ ○ /server-ai-agent-chatbot
├ ○ /server-ai-tracked-changes
├ ○ /server-ai-tracked-changes-comments
├ ○ /server-comments
├ ○ /server-comments-workflow
├ ○ /server-edit-workflow
├ ○ /server-insert-content-workflow
├ ○ /server-proofreader-workflow
├ ○ /server-selection-awareness
├ ○ /split-view
├ ○ /template-workflow
├ ○ /tiptap-edit-workflow
├ ○ /tool-streaming
├ ○ /tracked-changes
└ ○ /tracked-changes-comments


○  (Static)   prerendered as static content
ƒ  (Dynamic)  server-rendered on demand

## Notes
- 
> ai-toolkit-demos@0.1.0 lint /Users/arnaugomez/work/sessions/ai-toolkit-session-mechanism/worktrees/ai-toolkit-demos--fix-session-mechanism-pr45
> biome check

The number of diagnostics exceeds the limit allowed. Use --max-diagnostics to increase it.
Diagnostics not shown: 4.
Checked 106 files in 37ms. No fixes applied.
Found 23 errors.
Found 1 warning.
 ELIFECYCLE  Command failed with exit code 1. still fails on pre-existing formatting and style issues outside this change set, including  and multiple unrelated page files