### PR TITLE
fix: set initial text selection on demo load for selection-awareness pages

### DIFF
--- a/src/app/selection-awareness/page.tsx
+++ b/src/app/selection-awareness/page.tsx
@@ -19,6 +19,9 @@ export default function Page() {
     extensions: [StarterKit, AiToolkit, Selection],
     content: `<p>This is another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>
 <p>This is yet another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>`,
+    onCreate: ({ editor: e }) => {
+      e.commands.setTextSelection({ from: 274, to: 324 });
+    },
   });
 
   const { messages, sendMessage, addToolOutput, status } = useChat({

--- a/src/app/server-selection-awareness/page.tsx
+++ b/src/app/server-selection-awareness/page.tsx
@@ -62,6 +62,7 @@ export default function Page() {
           user: "user-1",
           onConnect() {
             editor?.commands.setContent(initialContent);
+            editor?.commands.setTextSelection({ from: 243, to: 291 });
           },
         });
 


### PR DESCRIPTION
## Summary
- Both selection-awareness demos now load with a sentence pre-selected in the editor, so users immediately see the selection feature in action.
- Client demo sets selection via `onCreate` callback; server demo sets it after `setContent` in `onConnect`.

## Test plan
- [ ] Open `/selection-awareness` and verify "This paragraph gives you more content to target." is selected on load
- [ ] Open `/server-selection-awareness` and verify the same sentence is selected on load