### PR TITLE
Add Insert Content workflow demos with review UI variants

### DIFF
--- a/src/app/insert-content-workflow-preview/page.tsx
+++ b/src/app/insert-content-workflow-preview/page.tsx
@@ -73,6 +73,7 @@ export default function Page() {
       position: selectionRange,
       reviewOptions: {
         mode: "preview",
+        useDiffUtility: false,
         displayOptions: {
           renderDecorations(options) {
             const decorations = [...options.defaultRenderDecorations()];

--- a/src/app/insert-content-workflow-preview/page.tsx
+++ b/src/app/insert-content-workflow-preview/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Selection } from "@tiptap/extensions";
+import { Decoration } from "@tiptap/pm/view";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { AiCaret, AiToolkit, getAiToolkit } from "@tiptap-pro/ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { SuggestionReviewTooltip } from "../../components/suggestion-review-tooltip";
+import { ToolbarPanel } from "../../components/toolbar-panel";
+import "../../styles/ai-caret.css";
+import "../../styles/suggestions-preview-mode.css";
+import "../insert-content-workflow/selection.css";
+
+type SuggestionTooltipMount = {
+  suggestionId: string;
+  element: HTMLElement;
+};
+
+export default function Page() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, AiToolkit, Selection, AiCaret],
+    content: `<p>Select some text and click the "Add emojis" button to add emojis to your selection.</p>
+<p>This is another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>
+<p>This is yet another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>`,
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [tooltipMount, setTooltipMount] =
+    useState<SuggestionTooltipMount | null>(null);
+  const selectionIsEmpty = useEditorState({
+    editor,
+    selector: (snapshot) => snapshot.editor?.state.selection.empty ?? true,
+  });
+
+  const hasSuggestions = useEditorState({
+    editor,
+    selector: (snapshot) => {
+      if (!snapshot.editor) return false;
+      return getAiToolkit(snapshot.editor).getSuggestions().length > 0;
+    },
+  });
+
+  if (!editor) return null;
+
+  const editSelection = async (task: string) => {
+    editor.commands.blur();
+    setIsLoading(true);
+
+    const toolkit = getAiToolkit(editor);
+    const selectionRange = editor.state.selection;
+    const selection = toolkit.getHtmlRange(selectionRange);
+
+    const response = await fetch("/api/insert-content-workflow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ task, replace: selection }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const readableStream = response.body;
+    if (!readableStream) {
+      throw new Error("No response body");
+    }
+
+    await toolkit.streamHtml(readableStream, {
+      position: selectionRange,
+      reviewOptions: {
+        mode: "preview",
+        displayOptions: {
+          renderDecorations(options) {
+            const decorations = [...options.defaultRenderDecorations()];
+
+            if (options.isSelected) {
+              decorations.push(
+                Decoration.widget(
+                  options.range.to,
+                  () => {
+                    const element = document.createElement("span");
+                    element.className =
+                      "inline-block h-px w-px align-middle opacity-0 pointer-events-none";
+
+                    setTooltipMount({
+                      suggestionId: options.suggestion.id,
+                      element,
+                    });
+
+                    return element;
+                  },
+                  {
+                    destroy() {
+                      setTooltipMount((prev) =>
+                        prev?.suggestionId === options.suggestion.id
+                          ? null
+                          : prev,
+                      );
+                    },
+                  },
+                ),
+              );
+            }
+
+            return decorations;
+          },
+        },
+      },
+    });
+
+    setIsLoading(false);
+  };
+
+  const disabled = selectionIsEmpty || isLoading;
+  const showReviewUI = !isLoading && hasSuggestions;
+
+  const buttonClassName =
+    "inline-flex items-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed";
+
+  return (
+    <div className="flex flex-col h-screen">
+      <ToolbarPanel>
+        <button
+          type="button"
+          onClick={() => editSelection("Add emojis to this text")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Add emojis"
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => editSelection("Make the text twice as long")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Make text longer"
+          )}
+        </button>
+        {showReviewUI && (
+          <>
+            <div className="w-px h-6 bg-slate-200" />
+            <button
+              type="button"
+              onClick={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.acceptAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-emerald-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-emerald-600 transition-all duration-200 cursor-pointer"
+            >
+              Accept all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.rejectAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-rose-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-rose-600 transition-all duration-200 cursor-pointer"
+            >
+              Reject all
+            </button>
+          </>
+        )}
+      </ToolbarPanel>
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+        {tooltipMount &&
+          createPortal(
+            <SuggestionReviewTooltip
+              referenceElement={tooltipMount.element}
+              text="Preview this change"
+              onAccept={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.acceptSuggestion(tooltipMount.suggestionId);
+              }}
+              onReject={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.rejectSuggestion(tooltipMount.suggestionId);
+              }}
+            />,
+            tooltipMount.element,
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/insert-content-workflow-review/page.tsx
+++ b/src/app/insert-content-workflow-review/page.tsx
@@ -73,6 +73,7 @@ export default function Page() {
       position: selectionRange,
       reviewOptions: {
         mode: "review",
+        useDiffUtility: false,
         displayOptions: {
           renderDecorations(options) {
             const decorations = [...options.defaultRenderDecorations()];

--- a/src/app/insert-content-workflow-review/page.tsx
+++ b/src/app/insert-content-workflow-review/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { Selection } from "@tiptap/extensions";
+import { Decoration } from "@tiptap/pm/view";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { AiCaret, AiToolkit, getAiToolkit } from "@tiptap-pro/ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { SuggestionReviewTooltip } from "../../components/suggestion-review-tooltip";
+import { ToolbarPanel } from "../../components/toolbar-panel";
+import "../../styles/ai-caret.css";
+import "../../styles/suggestions-review-mode.css";
+import "../insert-content-workflow/selection.css";
+
+type SuggestionTooltipMount = {
+  suggestionId: string;
+  element: HTMLElement;
+};
+
+export default function Page() {
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [StarterKit, AiToolkit, Selection, AiCaret],
+    content: `<p>Select some text and click the "Add emojis" button to add emojis to your selection.</p>
+<p>This is another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>
+<p>This is yet another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>`,
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [tooltipMount, setTooltipMount] =
+    useState<SuggestionTooltipMount | null>(null);
+  const selectionIsEmpty = useEditorState({
+    editor,
+    selector: (snapshot) => snapshot.editor?.state.selection.empty ?? true,
+  });
+
+  const hasSuggestions = useEditorState({
+    editor,
+    selector: (snapshot) => {
+      if (!snapshot.editor) return false;
+      return getAiToolkit(snapshot.editor).getSuggestions().length > 0;
+    },
+  });
+
+  if (!editor) return null;
+
+  const editSelection = async (task: string) => {
+    editor.commands.blur();
+    setIsLoading(true);
+
+    const toolkit = getAiToolkit(editor);
+    const selectionRange = editor.state.selection;
+    const selection = toolkit.getHtmlRange(selectionRange);
+
+    const response = await fetch("/api/insert-content-workflow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ task, replace: selection }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const readableStream = response.body;
+    if (!readableStream) {
+      throw new Error("No response body");
+    }
+
+    await toolkit.streamHtml(readableStream, {
+      position: selectionRange,
+      reviewOptions: {
+        mode: "review",
+        displayOptions: {
+          renderDecorations(options) {
+            const decorations = [...options.defaultRenderDecorations()];
+
+            if (options.isSelected) {
+              decorations.push(
+                Decoration.widget(
+                  options.range.to,
+                  () => {
+                    const element = document.createElement("span");
+                    element.className =
+                      "inline-block h-px w-px align-middle opacity-0 pointer-events-none";
+
+                    setTooltipMount({
+                      suggestionId: options.suggestion.id,
+                      element,
+                    });
+
+                    return element;
+                  },
+                  {
+                    destroy() {
+                      setTooltipMount((prev) =>
+                        prev?.suggestionId === options.suggestion.id
+                          ? null
+                          : prev,
+                      );
+                    },
+                  },
+                ),
+              );
+            }
+
+            return decorations;
+          },
+        },
+      },
+    });
+
+    setIsLoading(false);
+  };
+
+  const disabled = selectionIsEmpty || isLoading;
+  const showReviewUI = !isLoading && hasSuggestions;
+
+  const buttonClassName =
+    "inline-flex items-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed";
+
+  return (
+    <div className="flex flex-col h-screen">
+      <ToolbarPanel>
+        <button
+          type="button"
+          onClick={() => editSelection("Add emojis to this text")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Add emojis"
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => editSelection("Make the text twice as long")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Make text longer"
+          )}
+        </button>
+        {showReviewUI && (
+          <>
+            <div className="w-px h-6 bg-slate-200" />
+            <button
+              type="button"
+              onClick={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.acceptAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-emerald-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-emerald-600 transition-all duration-200 cursor-pointer"
+            >
+              Accept all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.rejectAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-rose-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-rose-600 transition-all duration-200 cursor-pointer"
+            >
+              Reject all
+            </button>
+          </>
+        )}
+      </ToolbarPanel>
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+        {tooltipMount &&
+          createPortal(
+            <SuggestionReviewTooltip
+              referenceElement={tooltipMount.element}
+              text="Review this change"
+              onAccept={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.acceptSuggestion(tooltipMount.suggestionId);
+              }}
+              onReject={() => {
+                const toolkit = getAiToolkit(editor);
+                toolkit.rejectSuggestion(tooltipMount.suggestionId);
+              }}
+            />,
+            tooltipMount.element,
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/insert-content-workflow-tracked-changes/page.tsx
+++ b/src/app/insert-content-workflow-tracked-changes/page.tsx
@@ -130,6 +130,7 @@ export default function Page() {
       position: selectionRange,
       reviewOptions: {
         mode: "trackedChanges",
+        useDiffUtility: false,
         trackedChangesOptions: {
           userId: "ai-assistant",
           userMetadata: {

--- a/src/app/insert-content-workflow-tracked-changes/page.tsx
+++ b/src/app/insert-content-workflow-tracked-changes/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { Selection } from "@tiptap/extensions";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { AiCaret, AiToolkit, getAiToolkit } from "@tiptap-pro/ai-toolkit";
+import {
+  findSuggestions,
+  TrackedChanges,
+} from "@tiptap-pro/extension-tracked-changes";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { SuggestionReviewTooltip } from "../../components/suggestion-review-tooltip";
+import { ToolbarPanel } from "../../components/toolbar-panel";
+import "../../styles/ai-caret.css";
+import "../../styles/tracked-changes.css";
+import "../insert-content-workflow/selection.css";
+
+type SuggestionTooltipMount = {
+  suggestionId: string;
+  element: HTMLElement;
+  text: string;
+};
+
+export default function Page() {
+  const [hasSuggestions, setHasSuggestions] = useState(false);
+  const [tooltipMount, setTooltipMount] =
+    useState<SuggestionTooltipMount | null>(null);
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit,
+      TrackedChanges.configure({ enabled: false }),
+      AiToolkit,
+      Selection,
+      AiCaret,
+    ],
+    content: `<p>Select some text and click the "Add emojis" button to add emojis to your selection.</p>
+<p>This is another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>
+<p>This is yet another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>`,
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const selectionIsEmpty = useEditorState({
+    editor,
+    selector: (snapshot) => snapshot.editor?.state.selection.empty ?? true,
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const updateSuggestionState = () => {
+      setHasSuggestions(findSuggestions(editor, "suggestion").length > 0);
+    };
+
+    const updateTooltip = () => {
+      const { from } = editor.state.selection;
+      const selectedSuggestion = findSuggestions(editor, "suggestion").find(
+        (suggestion) => from >= suggestion.from && from <= suggestion.to,
+      );
+
+      if (!selectedSuggestion) {
+        setTooltipMount(null);
+        return;
+      }
+
+      const coords = editor.view.coordsAtPos(selectedSuggestion.to);
+
+      if (!anchorRef.current) {
+        anchorRef.current = document.createElement("span");
+        anchorRef.current.style.cssText =
+          "position: fixed; width: 1px; height: 1px; pointer-events: none;";
+        document.body.appendChild(anchorRef.current);
+      }
+
+      anchorRef.current.style.left = `${coords.left}px`;
+      anchorRef.current.style.top = `${coords.top}px`;
+
+      setTooltipMount({
+        suggestionId: selectedSuggestion.id,
+        element: anchorRef.current,
+        text: "Review this tracked change",
+      });
+    };
+
+    updateSuggestionState();
+    updateTooltip();
+
+    editor.on("transaction", updateSuggestionState);
+    editor.on("selectionUpdate", updateTooltip);
+
+    return () => {
+      editor.off("transaction", updateSuggestionState);
+      editor.off("selectionUpdate", updateTooltip);
+      anchorRef.current?.remove();
+      anchorRef.current = null;
+    };
+  }, [editor]);
+
+  if (!editor) return null;
+
+  const editSelection = async (task: string) => {
+    editor.commands.blur();
+    setIsLoading(true);
+
+    const toolkit = getAiToolkit(editor);
+    const selectionRange = editor.state.selection;
+    const selection = toolkit.getHtmlRange(selectionRange);
+
+    const response = await fetch("/api/insert-content-workflow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ task, replace: selection }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const readableStream = response.body;
+    if (!readableStream) {
+      throw new Error("No response body");
+    }
+
+    await toolkit.streamHtml(readableStream, {
+      position: selectionRange,
+      reviewOptions: {
+        mode: "trackedChanges",
+        trackedChangesOptions: {
+          userId: "ai-assistant",
+          userMetadata: {
+            name: "AI",
+          },
+        },
+      },
+    });
+
+    setIsLoading(false);
+  };
+
+  const disabled = selectionIsEmpty || isLoading;
+  const showReviewUI = !isLoading && hasSuggestions;
+
+  const buttonClassName =
+    "inline-flex items-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed";
+
+  return (
+    <div className="flex flex-col h-screen">
+      <ToolbarPanel>
+        <button
+          type="button"
+          onClick={() => editSelection("Add emojis to this text")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Add emojis"
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => editSelection("Make the text twice as long")}
+          disabled={disabled}
+          className={buttonClassName}
+        >
+          {isLoading ? (
+            <>
+              <Loader2 className="animate-spin" size={14} /> Loading...
+            </>
+          ) : (
+            "Make text longer"
+          )}
+        </button>
+        {showReviewUI && (
+          <>
+            <div className="w-px h-6 bg-slate-200" />
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.acceptAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-emerald-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-emerald-600 transition-all duration-200 cursor-pointer"
+            >
+              Accept all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.rejectAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-rose-500 text-white px-2.5 py-1.5 text-sm font-medium hover:bg-rose-600 transition-all duration-200 cursor-pointer"
+            >
+              Reject all
+            </button>
+          </>
+        )}
+      </ToolbarPanel>
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+        {tooltipMount &&
+          createPortal(
+            <SuggestionReviewTooltip
+              referenceElement={tooltipMount.element}
+              text={tooltipMount.text}
+              onAccept={() => {
+                editor.commands.acceptSuggestion({
+                  id: tooltipMount.suggestionId,
+                });
+              }}
+              onReject={() => {
+                editor.commands.rejectSuggestion({
+                  id: tooltipMount.suggestionId,
+                });
+              }}
+            />,
+            tooltipMount.element,
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,6 +139,29 @@ const CATEGORIES = [
           },
         ],
       },
+      {
+        heading: "Insert Content + Review UI",
+        items: [
+          {
+            title: "Preview Changes",
+            description:
+              "Insert content workflow with preview mode — review before applying",
+            href: "/insert-content-workflow-preview",
+          },
+          {
+            title: "Review Changes",
+            description:
+              "Insert content workflow with review mode — changes applied, then accept or reject",
+            href: "/insert-content-workflow-review",
+          },
+          {
+            title: "Tracked Changes",
+            description:
+              "Insert content workflow with tracked changes — persistent collaborative review",
+            href: "/insert-content-workflow-tracked-changes",
+          },
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds three new demos of the Insert Content workflow, each showcasing a different review UI mode:
  - **Preview Changes** (`/insert-content-workflow-preview`): Changes are shown as decorations before being applied. The user can accept or reject individual suggestions via tooltip, or all at once via toolbar buttons.
  - **Review Changes** (`/insert-content-workflow-review`): Changes are applied immediately but displayed as suggestions that can be accepted or rejected afterward.
  - **Tracked Changes** (`/insert-content-workflow-tracked-changes`): Changes are written as persistent tracked changes using the `TrackedChanges` extension.
- All three demos reuse the existing `/api/insert-content-workflow` API route and follow the toolbar-based UI pattern (matching the original Insert Content demo).
- Updated the home page to list the new demos under a "Insert Content + Review UI" group in the Workflows section.

## Test plan

- [ ] Visit `/insert-content-workflow-preview`, select text, click a button, and verify suggestions appear as decorations with accept/reject tooltip
- [ ] Visit `/insert-content-workflow-review`, select text, click a button, and verify changes are applied with review decorations
- [ ] Visit `/insert-content-workflow-tracked-changes`, select text, click a button, and verify changes appear as tracked changes
- [ ] Verify "Accept all" and "Reject all" buttons work in each demo
- [ ] Verify the home page shows the new demos under the Workflows section