### PR TITLE
feat: add server workflow tracked changes review UI demos

### DIFF
--- a/src/app/api/server-edit-workflow-tracked-changes/route.ts
+++ b/src/app/api/server-edit-workflow-tracked-changes/route.ts
@@ -1,0 +1,103 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { gateway, Output, streamText, wrapLanguageModel } from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  executeWorkflowEdit,
+  getWorkflowDefinition,
+  readWorkflowDocument,
+} from "@/lib/server-ai-toolkit/workflow-api";
+
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+    }
+  }
+
+  const {
+    documentId,
+    schemaAwarenessData,
+    task,
+    sessionId,
+  }: {
+    documentId: string;
+    schemaAwarenessData: unknown;
+    task: string;
+    sessionId?: string | null;
+  } = await req.json();
+
+  const readResult = await readWorkflowDocument({
+    schemaAwarenessData,
+    sessionId,
+    format: "shorthand",
+    reviewOptions: {
+      mode: "disabled",
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  if (!readResult.output.success || !readResult.output.content) {
+    throw new Error(readResult.output.error ?? "Failed to read document");
+  }
+
+  const [workflow, schemaAwarenessPrompt] = await Promise.all([
+    getWorkflowDefinition("edit", "shorthand"),
+    getSchemaAwarenessPrompt(schemaAwarenessData),
+  ]);
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const result = streamText({
+    model,
+    system: `${workflow.systemPrompt}\n\n${schemaAwarenessPrompt}`,
+    prompt: JSON.stringify({
+      content: readResult.output.content,
+      task,
+    }),
+    output: Output.object({ schema: z.fromJSONSchema(workflow.outputSchema) }),
+    providerOptions: {
+      openai: {
+        reasoningEffort: "low",
+      },
+    },
+  });
+  const output = await result.output;
+
+  const executeResult = await executeWorkflowEdit({
+    schemaAwarenessData,
+    format: "shorthand",
+    input: output,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: "trackedChanges",
+      trackedChangesOptions: {
+        userId: "ai-assistant",
+      },
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  return Response.json({
+    sessionId: executeResult.sessionId,
+    operationResults: executeResult.output.operationResults ?? [],
+  });
+}

--- a/src/app/api/server-insert-content-workflow-tracked-changes/route.ts
+++ b/src/app/api/server-insert-content-workflow-tracked-changes/route.ts
@@ -1,0 +1,109 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { gateway, Output, streamText, wrapLanguageModel } from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  executeWorkflowInsertContent,
+  getWorkflowDefinition,
+  readWorkflowSelection,
+} from "@/lib/server-ai-toolkit/workflow-api";
+
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+    }
+  }
+
+  const {
+    documentId,
+    schemaAwarenessData,
+    task,
+    range,
+    sessionId,
+  }: {
+    documentId: string;
+    schemaAwarenessData: unknown;
+    task: string;
+    range: { from: number; to: number };
+    sessionId?: string | null;
+  } = await req.json();
+
+  const readResult = await readWorkflowSelection({
+    schemaAwarenessData,
+    range,
+    sessionId,
+    format: "shorthand",
+    reviewOptions: {
+      mode: "disabled",
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  if (readResult.output.isEmpty) {
+    throw new Error("No selection available for insert-content workflow");
+  }
+
+  const [workflow, schemaAwarenessPrompt] = await Promise.all([
+    getWorkflowDefinition("insert-content", "shorthand"),
+    getSchemaAwarenessPrompt(schemaAwarenessData),
+  ]);
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const result = streamText({
+    model,
+    system: `${workflow.systemPrompt}\n\n${schemaAwarenessPrompt}`,
+    prompt: JSON.stringify({
+      task,
+      replace: readResult.output.content,
+      context: readResult.output.prompt,
+    }),
+    output: Output.object({ schema: z.fromJSONSchema(workflow.outputSchema) }),
+    providerOptions: {
+      openai: {
+        reasoningEffort: "low",
+      },
+    },
+  });
+  const workflowOutput = (await result.output) as { content: string };
+
+  const executeResult = await executeWorkflowInsertContent({
+    schemaAwarenessData,
+    format: "shorthand",
+    input: workflowOutput.content,
+    range,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: "trackedChanges",
+      trackedChangesOptions: {
+        userId: "ai-assistant",
+      },
+      useDiffUtility: false,
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  return Response.json({
+    sessionId: executeResult.sessionId,
+    range: executeResult.output.range ?? null,
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,6 +213,12 @@ const CATEGORIES = [
             href: "/server-insert-content-workflow",
           },
           {
+            title: "Server Insert + Tracked",
+            description:
+              "Insert content workflow that writes AI changes as tracked changes for review",
+            href: "/server-insert-content-workflow-tracked-changes",
+          },
+          {
             title: "Server Proofreader",
             description:
               "Proofreading workflow with server-side tracked changes output",
@@ -223,6 +229,12 @@ const CATEGORIES = [
             description:
               "Prompt-driven document editing via server workflow endpoints",
             href: "/server-edit-workflow",
+          },
+          {
+            title: "Server Edit + Tracked",
+            description:
+              "Edit workflow that writes AI changes as tracked changes for review",
+            href: "/server-edit-workflow-tracked-changes",
           },
           {
             title: "Server Comments Workflow",

--- a/src/app/server-edit-workflow-tracked-changes/page.tsx
+++ b/src/app/server-edit-workflow-tracked-changes/page.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Collaboration } from "@tiptap/extension-collaboration";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  findSuggestions,
+  TrackedChanges,
+} from "@tiptap-pro/extension-tracked-changes";
+import { TiptapCollabProvider } from "@tiptap-pro/provider";
+import {
+  getSchemaAwarenessData,
+  ServerAiToolkit,
+} from "@tiptap-pro/server-ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+import * as Y from "yjs";
+import "../../styles/tracked-changes.css";
+import { getCollabConfig } from "../server-ai-agent-chatbot/actions";
+
+const INITIAL_CONTENT = `<h1>Document Editor Demo</h1>
+<p>This is a sample document that can be edited by AI. The text here is informal and could use some improvements.</p>
+<p>You can ask the AI to make the text more formal, add more details, simplify it, or transform it in any way you like.</p>
+<p>Try different tasks to see how the AI can help you edit your documents!</p>`;
+
+export default function Page() {
+  const [doc] = useState(() => new Y.Doc());
+  const [documentId] = useState(
+    () => `server-edit-workflow-tracked-changes/${uuid()}`,
+  );
+  const providerRef = useRef<TiptapCollabProvider | null>(null);
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Collaboration.configure({ document: doc }),
+      ServerAiToolkit,
+      TrackedChanges.configure({
+        enabled: false,
+      }),
+    ],
+  });
+  const [task, setTask] = useState(
+    "Make the text more formal and professional, but do not change the title",
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [hasSuggestions, setHasSuggestions] = useState(false);
+
+  useEffect(() => {
+    const setupProvider = async () => {
+      try {
+        const { token, appId, collabBaseUrl } = await getCollabConfig(
+          "user-1",
+          documentId,
+        );
+
+        const collabProvider = new TiptapCollabProvider({
+          ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
+          name: documentId,
+          token,
+          document: doc,
+          user: "user-1",
+          onConnect() {
+            editor?.commands.setContent(INITIAL_CONTENT);
+          },
+        });
+
+        providerRef.current = collabProvider;
+      } catch (error) {
+        console.error("Failed to setup collaboration:", error);
+      }
+    };
+
+    setupProvider();
+
+    return () => {
+      if (providerRef.current) {
+        providerRef.current.destroy();
+        providerRef.current = null;
+      }
+    };
+  }, [doc, documentId, editor]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const updateSuggestionState = () => {
+      setHasSuggestions(findSuggestions(editor, "suggestion").length > 0);
+    };
+
+    updateSuggestionState();
+    editor.on("transaction", updateSuggestionState);
+
+    return () => {
+      editor.off("transaction", updateSuggestionState);
+    };
+  }, [editor]);
+
+  if (!editor) {
+    return null;
+  }
+
+  const editDocument = async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(
+        "/api/server-edit-workflow-tracked-changes",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            documentId,
+            schemaAwarenessData: getSchemaAwarenessData(editor),
+            task,
+            sessionId,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+
+      const result: { sessionId: string } = await response.json();
+      setSessionId(result.sessionId);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-screen tracked-changes-demo">
+      <div className="flex flex-col sm:flex-row sm:items-start gap-2 border-b border-slate-200 bg-white px-4 py-3">
+        <textarea
+          value={task}
+          onChange={(event) => {
+            setTask(event.target.value);
+            event.target.style.height = "auto";
+            event.target.style.height = `${event.target.scrollHeight}px`;
+          }}
+          placeholder="Enter editing task..."
+          rows={1}
+          className="flex-1 resize-none border border-[var(--gray-3)] rounded-lg px-3 py-1.5 text-sm focus:border-[var(--purple)] focus:outline-none min-h-16 sm:min-h-0"
+        />
+        {hasSuggestions ? (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.acceptAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--green)] text-white hover:opacity-90 transition-all duration-200 cursor-pointer"
+            >
+              Accept all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.rejectAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--gray-2)] text-[var(--black)] hover:bg-[var(--gray-3)] transition-all duration-200 cursor-pointer"
+            >
+              Reject all
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={editDocument}
+            disabled={isLoading || !task.trim()}
+            className="inline-flex items-center justify-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed w-full sm:w-auto"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="animate-spin" size={14} /> Editing...
+              </>
+            ) : (
+              "Edit Document"
+            )}
+          </button>
+        )}
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/server-insert-content-workflow-tracked-changes/page.tsx
+++ b/src/app/server-insert-content-workflow-tracked-changes/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { Collaboration } from "@tiptap/extension-collaboration";
+import { Selection } from "@tiptap/extensions";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  findSuggestions,
+  TrackedChanges,
+} from "@tiptap-pro/extension-tracked-changes";
+import { TiptapCollabProvider } from "@tiptap-pro/provider";
+import {
+  getSchemaAwarenessData,
+  ServerAiToolkit,
+} from "@tiptap-pro/server-ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+import * as Y from "yjs";
+import { ToolbarPanel } from "../../components/toolbar-panel";
+import "../../styles/tracked-changes.css";
+import "../insert-content-workflow/selection.css";
+import { getCollabConfig } from "../server-ai-agent-chatbot/actions";
+
+const INITIAL_CONTENT = `<p>Select some text and click the "Add emojis" button to add emojis to your selection.</p>
+<p>This is another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>
+<p>This is yet another paragraph that you can select. Tiptap is a rich text editor that you can use to edit your text. It is a powerful tool that you can use to create beautiful documents. With the AI Toolkit, you can give your AI the ability to edit your document in real time.</p>`;
+
+export default function Page() {
+  const [doc] = useState(() => new Y.Doc());
+  const [documentId] = useState(
+    () => `server-insert-content-workflow-tracked-changes/${uuid()}`,
+  );
+  const providerRef = useRef<TiptapCollabProvider | null>(null);
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Collaboration.configure({ document: doc }),
+      ServerAiToolkit,
+      Selection,
+      TrackedChanges.configure({
+        enabled: false,
+      }),
+    ],
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [hasSuggestions, setHasSuggestions] = useState(false);
+
+  useEffect(() => {
+    const setupProvider = async () => {
+      try {
+        const { token, appId, collabBaseUrl } = await getCollabConfig(
+          "user-1",
+          documentId,
+        );
+
+        const collabProvider = new TiptapCollabProvider({
+          ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
+          name: documentId,
+          token,
+          document: doc,
+          user: "user-1",
+          onConnect() {
+            editor?.commands.setContent(INITIAL_CONTENT);
+          },
+        });
+
+        providerRef.current = collabProvider;
+      } catch (error) {
+        console.error("Failed to setup collaboration:", error);
+      }
+    };
+
+    setupProvider();
+
+    return () => {
+      if (providerRef.current) {
+        providerRef.current.destroy();
+        providerRef.current = null;
+      }
+    };
+  }, [doc, documentId, editor]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const updateSuggestionState = () => {
+      setHasSuggestions(findSuggestions(editor, "suggestion").length > 0);
+    };
+
+    updateSuggestionState();
+    editor.on("transaction", updateSuggestionState);
+
+    return () => {
+      editor.off("transaction", updateSuggestionState);
+    };
+  }, [editor]);
+
+  const selectionIsEmpty = useEditorState({
+    editor,
+    selector: (snapshot) => snapshot.editor?.state.selection.empty ?? true,
+  });
+
+  if (!editor) {
+    return null;
+  }
+
+  const editSelection = async (task: string) => {
+    setIsLoading(true);
+
+    try {
+      const { from, to } = editor.state.selection;
+      const response = await fetch(
+        "/api/server-insert-content-workflow-tracked-changes",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            documentId,
+            schemaAwarenessData: getSchemaAwarenessData(editor),
+            task,
+            sessionId,
+            range: { from, to },
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+
+      const result: {
+        sessionId: string;
+        range: { from: number; to: number } | null;
+      } = await response.json();
+      setSessionId(result.sessionId);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const disabled = selectionIsEmpty || isLoading;
+  const buttonClassName =
+    "inline-flex items-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed";
+
+  return (
+    <div className="flex flex-col h-screen tracked-changes-demo">
+      <ToolbarPanel>
+        {hasSuggestions ? (
+          <>
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.acceptAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--green)] text-white hover:opacity-90 transition-all duration-200 cursor-pointer"
+            >
+              Accept all
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                editor.commands.rejectAllSuggestions();
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--gray-2)] text-[var(--black)] hover:bg-[var(--gray-3)] transition-all duration-200 cursor-pointer"
+            >
+              Reject all
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => editSelection("Add emojis to this text")}
+              disabled={disabled}
+              className={buttonClassName}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="animate-spin" size={14} /> Loading...
+                </>
+              ) : (
+                "Add emojis"
+              )}
+            </button>
+            <button
+              type="button"
+              onClick={() => editSelection("Make the text twice as long")}
+              disabled={disabled}
+              className={buttonClassName}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="animate-spin" size={14} /> Loading...
+                </>
+              ) : (
+                "Make text longer"
+              )}
+            </button>
+          </>
+        )}
+      </ToolbarPanel>
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/server-ai-toolkit/workflow-api.ts
+++ b/src/lib/server-ai-toolkit/workflow-api.ts
@@ -8,6 +8,7 @@ interface ReviewOptions {
     userId: string;
     userMetadata?: Record<string, unknown> | null;
   };
+  useDiffUtility?: boolean;
 }
 
 interface InlineDocumentSource {


### PR DESCRIPTION
## Summary

Adds two new Server AI Toolkit workflow demos that integrate the Tracked Changes extension for review UI:

- **Server Edit + Tracked** (`/server-edit-workflow-tracked-changes`) — Tiptap Edit workflow with `reviewOptions: { mode: 'trackedChanges' }`. AI edits become tracked-change suggestions reviewed via Accept all / Reject all toolbar.
- **Server Insert + Tracked** (`/server-insert-content-workflow-tracked-changes`) — Insert Content workflow with `useDiffUtility: false`. Selection-based AI insertion with tracked-change review.

Both demos follow the existing `server-proofreader-workflow` pattern (TrackedChanges extension + `findSuggestions` + conditional toolbar) and require no changes to the Server AI Toolkit (sao-paulo) — server already supports `reviewOptions.mode: 'trackedChanges'` for both workflows.

### Changes

- New routes + pages for the two demos
- Home page (`src/app/page.tsx`) — two new entries under Server AI Toolkit > Workflows
- `src/lib/server-ai-toolkit/workflow-api.ts` — added optional `useDiffUtility?: boolean` to `ReviewOptions` (used by Insert Content per docs guidance)

### Out of scope

- **Tracked Changes + Comments** demos for Edit and Proofreader workflows — these require Server AI Toolkit support for `operationMeta` in workflow output schema (currently only available in agent flow). A separate ticket / PR on the Server AI Toolkit side is needed before these demos can be built.
- **Proofreader without Tracked Changes** demo — pending UX decision.

## Test plan

- [ ] `/server-edit-workflow-tracked-changes` — Click "Edit Document" → AI changes appear as green/red tracked changes → Accept all / Reject all work
- [ ] `/server-insert-content-workflow-tracked-changes` — Select text → "Add emojis" / "Make text longer" → tracked changes appear → Accept / Reject work
- [ ] Sidebar: both demos discoverable from home page under "Server AI Toolkit > Workflows"
- [ ] Lint / typecheck pass: `pnpm lint:fix`