### PR TITLE
feat: add server workflow tracked changes + comments review UI demos

### DIFF
--- a/src/app/api/server-edit-workflow-tracked-comments/route.ts
+++ b/src/app/api/server-edit-workflow-tracked-comments/route.ts
@@ -1,0 +1,112 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { gateway, Output, streamText, wrapLanguageModel } from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  executeWorkflowEdit,
+  getWorkflowDefinition,
+  readWorkflowDocument,
+} from "@/lib/server-ai-toolkit/workflow-api";
+
+const OPERATION_META_DESCRIPTION =
+  "Specific reason for THIS edit (what is changing in this exact operation). Each operation must have its own unique meta — do not repeat justifications across operations.";
+
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+    }
+  }
+
+  const {
+    documentId,
+    schemaAwarenessData,
+    task,
+    sessionId,
+  }: {
+    documentId: string;
+    schemaAwarenessData: unknown;
+    task: string;
+    sessionId?: string | null;
+  } = await req.json();
+
+  const readResult = await readWorkflowDocument({
+    schemaAwarenessData,
+    sessionId,
+    format: "shorthand",
+    reviewOptions: {
+      mode: "disabled",
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  if (!readResult.output.success || !readResult.output.content) {
+    throw new Error(readResult.output.error ?? "Failed to read document");
+  }
+
+  const [workflow, schemaAwarenessPrompt] = await Promise.all([
+    getWorkflowDefinition("edit", "shorthand", {
+      operationMeta: OPERATION_META_DESCRIPTION,
+    }),
+    getSchemaAwarenessPrompt(schemaAwarenessData),
+  ]);
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const result = streamText({
+    model,
+    system: `${workflow.systemPrompt}\n\n${schemaAwarenessPrompt}`,
+    prompt: JSON.stringify({
+      content: readResult.output.content,
+      task,
+    }),
+    output: Output.object({ schema: z.fromJSONSchema(workflow.outputSchema) }),
+    providerOptions: {
+      openai: {
+        reasoningEffort: "low",
+      },
+    },
+  });
+  const output = await result.output;
+
+  const executeResult = await executeWorkflowEdit({
+    schemaAwarenessData,
+    format: "shorthand",
+    input: output,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: "trackedChanges",
+      trackedChangesOptions: {
+        userId: "ai-assistant",
+      },
+    },
+    experimental_commentsOptions: {
+      threadData: { userName: "Tiptap AI" },
+      commentData: { userName: "Tiptap AI" },
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  return Response.json({
+    sessionId: executeResult.sessionId,
+    operationResults: executeResult.output.operationResults ?? [],
+  });
+}

--- a/src/app/api/server-proofreader-workflow-tracked-comments/route.ts
+++ b/src/app/api/server-proofreader-workflow-tracked-comments/route.ts
@@ -1,0 +1,121 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import { gateway, Output, streamText, wrapLanguageModel } from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getSchemaAwarenessPrompt } from "@/lib/server-ai-toolkit/get-schema-awareness-prompt";
+import {
+  executeWorkflowProofreader,
+  getWorkflowDefinition,
+  readWorkflowDocument,
+} from "@/lib/server-ai-toolkit/workflow-api";
+
+const OPERATION_META_DESCRIPTION =
+  "Specific reason for THIS correction (e.g., 'spelling: excelent → excellent' or 'subject-verb agreement'). Each operation must have its own unique meta — do not repeat justifications across operations.";
+
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: {
+          "Content-Type": "text/plain",
+        },
+      });
+    }
+  }
+
+  const {
+    documentId,
+    schemaAwarenessData,
+    sessionId,
+  }: {
+    documentId: string;
+    schemaAwarenessData: unknown;
+    sessionId?: string | null;
+  } = await req.json();
+
+  const readResult = await readWorkflowDocument({
+    schemaAwarenessData,
+    sessionId,
+    format: "shorthand",
+    reviewOptions: {
+      mode: "disabled",
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  if (
+    !readResult.output.success ||
+    typeof readResult.output.content !== "string"
+  ) {
+    throw new Error(readResult.output.error ?? "Failed to read document");
+  }
+
+  const [workflow, schemaAwarenessPrompt] = await Promise.all([
+    getWorkflowDefinition("proofreader", "shorthand", {
+      operationMeta: OPERATION_META_DESCRIPTION,
+    }),
+    getSchemaAwarenessPrompt(schemaAwarenessData),
+  ]);
+  const systemPrompt = `${workflow.systemPrompt}
+
+You are reviewing a demo document that intentionally contains grammar and spelling mistakes.
+If the content contains mistakes, do not return an empty operations array.
+Return the concrete proofreader operations needed to correct the mistakes.
+
+${schemaAwarenessPrompt}`;
+  const prompt = JSON.stringify({
+    content: readResult.output.content,
+    task: "Correct all grammar and spelling mistakes",
+  });
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const result = streamText({
+    model,
+    system: systemPrompt,
+    prompt,
+    output: Output.object({ schema: z.fromJSONSchema(workflow.outputSchema) }),
+    providerOptions: {
+      openai: {
+        reasoningEffort: "low",
+      },
+    },
+  });
+  const output = (await result.output) as { operations?: unknown[] };
+
+  const executeResult = await executeWorkflowProofreader({
+    schemaAwarenessData,
+    format: "shorthand",
+    input: output,
+    sessionId: readResult.sessionId,
+    reviewOptions: {
+      mode: "trackedChanges",
+      trackedChangesOptions: {
+        userId: "ai-assistant",
+      },
+    },
+    experimental_commentsOptions: {
+      threadData: { userName: "Tiptap AI" },
+      commentData: { userName: "Tiptap AI" },
+    },
+    experimental_documentOptions: {
+      documentId,
+      userId: "ai-assistant",
+    },
+  });
+
+  return Response.json({
+    sessionId: executeResult.sessionId,
+    operationResults: executeResult.output.operationResults,
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -225,6 +225,12 @@ const CATEGORIES = [
             href: "/server-proofreader-workflow",
           },
           {
+            title: "Server Proofreader + Tracked + Comments",
+            description:
+              "Proofreading workflow with tracked changes and AI justification comments",
+            href: "/server-proofreader-workflow-tracked-comments",
+          },
+          {
             title: "Server Edit Workflow",
             description:
               "Prompt-driven document editing via server workflow endpoints",
@@ -235,6 +241,12 @@ const CATEGORIES = [
             description:
               "Edit workflow that writes AI changes as tracked changes for review",
             href: "/server-edit-workflow-tracked-changes",
+          },
+          {
+            title: "Server Edit + Tracked + Comments",
+            description:
+              "Edit workflow with tracked changes and linked AI justification comments",
+            href: "/server-edit-workflow-tracked-comments",
           },
           {
             title: "Server Comments Workflow",

--- a/src/app/server-edit-workflow-tracked-comments/page.tsx
+++ b/src/app/server-edit-workflow-tracked-comments/page.tsx
@@ -1,0 +1,434 @@
+"use client";
+
+import { Collaboration } from "@tiptap/extension-collaboration";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  CommentsKit,
+  hoverOffThread,
+  hoverThread,
+} from "@tiptap-pro/extension-comments";
+import {
+  findSuggestions,
+  TrackedChanges,
+} from "@tiptap-pro/extension-tracked-changes";
+import { TiptapCollabProvider } from "@tiptap-pro/provider";
+import {
+  getSchemaAwarenessData,
+  ServerAiToolkit,
+} from "@tiptap-pro/server-ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { v4 as uuid } from "uuid";
+import * as Y from "yjs";
+import { ThreadsList } from "../../demos/comments/React/components/ThreadsList.jsx";
+import { ThreadsProvider } from "../../demos/comments/React/context.jsx";
+import { useThreads } from "../../demos/comments/React/hooks/useThreads.jsx";
+import { useUser } from "../../demos/comments/React/hooks/useUser.jsx";
+import "../../demos/comments/React/styles.scss";
+import "../../demos/comments/style.scss";
+import "../../styles/tracked-changes.css";
+import { getCollabConfig } from "../server-ai-agent-chatbot/actions";
+
+const INITIAL_CONTENT = `<h1>Document Editor Demo</h1>
+<p>This is a sample document that can be edited by AI. The text here is informal and could use some improvements.</p>
+<p>You can ask the AI to make the text more formal, add more details, simplify it, or transform it in any way you like.</p>
+<p>Try different tasks to see how the AI can help you edit your documents!</p>`;
+
+type DemoThread = {
+  id: string;
+  resolvedAt?: string | null;
+  data?: {
+    suggestionId?: string;
+    suggestionReason?: string;
+  };
+};
+
+export default function Page() {
+  const [isMounted, setIsMounted] = useState(false);
+  const [doc] = useState(() => new Y.Doc());
+  const [documentId] = useState(
+    () => `server-edit-workflow-tracked-comments/${uuid()}`,
+  );
+  const [provider, setProvider] = useState<TiptapCollabProvider | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+
+    let collabProvider: TiptapCollabProvider | null = null;
+
+    const setupProvider = async () => {
+      try {
+        const { token, appId, collabBaseUrl } = await getCollabConfig(
+          "user-1",
+          documentId,
+        );
+
+        collabProvider = new TiptapCollabProvider({
+          ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
+          name: documentId,
+          token,
+          document: doc,
+          user: "user-1",
+        });
+
+        setProvider(collabProvider);
+      } catch (error) {
+        console.error("Failed to setup collaboration:", error);
+      }
+    };
+
+    setupProvider();
+
+    return () => {
+      collabProvider?.destroy();
+    };
+  }, [documentId, doc, isMounted]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  if (!provider) {
+    return (
+      <div className="tracked-changes-comments-demo flex h-screen items-center justify-center bg-white">
+        <div className="space-y-2 text-center">
+          <div className="label-large">Loading collaboration document</div>
+          <p className="label-small text-slate-500">
+            Mounting the comments provider before the editor initializes.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <EditWorkflowCommentsEditor
+      doc={doc}
+      documentId={documentId}
+      provider={provider}
+    />
+  );
+}
+
+type EditWorkflowCommentsEditorProps = {
+  doc: Y.Doc;
+  documentId: string;
+  provider: TiptapCollabProvider;
+};
+
+function EditWorkflowCommentsEditor({
+  doc,
+  documentId,
+  provider,
+}: EditWorkflowCommentsEditorProps) {
+  const user = useUser();
+  const [hasSuggestions, setHasSuggestions] = useState(false);
+  const [selectedThread, setSelectedThread] = useState<string | null>(null);
+  const [task, setTask] = useState(
+    "Make the text more formal and professional, but do not change the title",
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        undoRedo: false,
+      }),
+      Collaboration.configure({
+        document: doc,
+      }),
+      ServerAiToolkit,
+      TrackedChanges.configure({
+        enabled: false,
+      }),
+      CommentsKit.configure({
+        provider,
+        onClickThread: (threadId: string | null) => {
+          if (!threadId) {
+            setSelectedThread(null);
+            editor?.chain().unselectThread().run();
+            return;
+          }
+
+          setSelectedThread(threadId);
+          editor
+            ?.chain()
+            .selectThread({ id: threadId, updateSelection: false })
+            .run();
+        },
+      }),
+    ],
+    editorProps: {
+      attributes: {
+        // @ts-expect-error spellcheck is a valid DOM attribute
+        spellcheck: false,
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (!editor || !provider) {
+      return;
+    }
+
+    const handleSync = () => {
+      if (editor.isEmpty) {
+        editor.commands.setContent(INITIAL_CONTENT);
+      }
+    };
+
+    if (provider.isSynced) {
+      handleSync();
+    } else {
+      provider.on("synced", handleSync);
+    }
+
+    return () => {
+      provider.off("synced", handleSync);
+    };
+  }, [editor, provider]);
+
+  const threadsResult = useThreads(provider, editor, user);
+  const threads: DemoThread[] = Array.isArray(threadsResult.threads)
+    ? threadsResult.threads
+    : [];
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const updateSuggestionState = () => {
+      setHasSuggestions(findSuggestions(editor, "suggestion").length > 0);
+    };
+
+    updateSuggestionState();
+    editor.on("transaction", updateSuggestionState);
+
+    return () => {
+      editor.off("transaction", updateSuggestionState);
+    };
+  }, [editor]);
+
+  const selectThreadInEditor = useCallback(
+    (threadId: string) => {
+      editor?.chain().selectThread({ id: threadId }).run();
+    },
+    [editor],
+  );
+
+  const deleteThread = useCallback(
+    (threadId: string) => {
+      provider.deleteThread(threadId);
+      editor?.commands.removeThread({ id: threadId });
+    },
+    [editor, provider],
+  );
+
+  const resolveThread = useCallback(
+    (threadId: string) => {
+      editor?.commands.resolveThread({ id: threadId });
+    },
+    [editor],
+  );
+
+  const unresolveThread = useCallback(
+    (threadId: string) => {
+      editor?.commands.unresolveThread({ id: threadId });
+    },
+    [editor],
+  );
+
+  const updateComment = useCallback(
+    (
+      threadId: string,
+      commentId: string,
+      content: string,
+      metaData: Record<string, string>,
+    ) => {
+      editor?.commands.updateComment({
+        threadId,
+        id: commentId,
+        content,
+        data: metaData,
+      });
+    },
+    [editor],
+  );
+
+  const onHoverThread = useCallback(
+    (threadId: number) => {
+      if (!editor) {
+        return;
+      }
+      // hoverThread / hoverOffThread read editor history state, which is null
+      // when StarterKit's `undoRedo` extension is disabled (the established
+      // demo pattern). The hover effect is purely visual, so failures here
+      // are safe to swallow.
+      try {
+        hoverThread(editor, [threadId]);
+      } catch {
+        // best-effort
+      }
+    },
+    [editor],
+  );
+
+  const onLeaveThread = useCallback(() => {
+    if (!editor) {
+      return;
+    }
+    try {
+      hoverOffThread(editor);
+    } catch {
+      // best-effort
+    }
+  }, [editor]);
+
+  if (!editor) {
+    return null;
+  }
+
+  const editDocument = async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(
+        "/api/server-edit-workflow-tracked-comments",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            documentId,
+            schemaAwarenessData: getSchemaAwarenessData(editor),
+            task,
+            sessionId,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+
+      const result: { sessionId: string } = await response.json();
+      setSessionId(result.sessionId);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const openThreads = threads.filter((thread) => !thread.resolvedAt);
+
+  return (
+    <ThreadsProvider
+      // @ts-expect-error JSX interop with JS comments demo code
+      onClickThread={selectThreadInEditor}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onDeleteThread={deleteThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onHoverThread={onHoverThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onLeaveThread={onLeaveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onResolveThread={resolveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onUpdateComment={updateComment}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onUnresolveThread={unresolveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      selectedThreads={editor.storage.comments?.focusedThreads ?? []}
+      // @ts-expect-error JSX interop with JS comments demo code
+      selectedThread={selectedThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      setSelectedThread={setSelectedThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      threads={threads}
+    >
+      <div className="tracked-changes-comments-demo flex flex-col h-screen">
+        <div className="flex flex-col sm:flex-row sm:items-start gap-2 border-b border-slate-200 bg-white px-4 py-3">
+          <textarea
+            value={task}
+            onChange={(event) => {
+              setTask(event.target.value);
+              event.target.style.height = "auto";
+              event.target.style.height = `${event.target.scrollHeight}px`;
+            }}
+            placeholder="Enter editing task..."
+            rows={1}
+            className="flex-1 resize-none border border-[var(--gray-3)] rounded-lg px-3 py-1.5 text-sm focus:border-[var(--purple)] focus:outline-none min-h-16 sm:min-h-0"
+          />
+          {hasSuggestions ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  editor.commands.acceptAllSuggestions();
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--green)] text-white hover:opacity-90 transition-all duration-200 cursor-pointer"
+              >
+                Accept all
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  editor.commands.rejectAllSuggestions();
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--gray-2)] text-[var(--black)] hover:bg-[var(--gray-3)] transition-all duration-200 cursor-pointer"
+              >
+                Reject all
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={editDocument}
+              disabled={isLoading || !task.trim()}
+              className="inline-flex items-center justify-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed w-full sm:w-auto"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="animate-spin" size={14} /> Editing...
+                </>
+              ) : (
+                "Edit Document"
+              )}
+            </button>
+          )}
+        </div>
+        <div
+          className="col-group divide-x divide-gray-200 flex-1 overflow-hidden"
+          data-viewmode="open"
+        >
+          <aside className="sidebar border-r border-gray-200 bg-white">
+            <div className="space-y-3">
+              <div>
+                <div className="label-large">Comments</div>
+                <p className="label-small mt-1">
+                  Each AI edit operation's justification becomes a comment
+                  thread linked to its tracked change.
+                </p>
+              </div>
+              <ThreadsList provider={provider} threads={openThreads} />
+            </div>
+          </aside>
+
+          <div className="main overflow-y-auto">
+            <EditorContent editor={editor} />
+          </div>
+        </div>
+      </div>
+    </ThreadsProvider>
+  );
+}

--- a/src/app/server-proofreader-workflow-tracked-comments/page.tsx
+++ b/src/app/server-proofreader-workflow-tracked-comments/page.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { Collaboration } from "@tiptap/extension-collaboration";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  CommentsKit,
+  hoverOffThread,
+  hoverThread,
+} from "@tiptap-pro/extension-comments";
+import {
+  findSuggestions,
+  TrackedChanges,
+} from "@tiptap-pro/extension-tracked-changes";
+import { TiptapCollabProvider } from "@tiptap-pro/provider";
+import {
+  getSchemaAwarenessData,
+  ServerAiToolkit,
+} from "@tiptap-pro/server-ai-toolkit";
+import { Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { v4 as uuid } from "uuid";
+import * as Y from "yjs";
+import { ToolbarPanel } from "../../components/toolbar-panel";
+import { ThreadsList } from "../../demos/comments/React/components/ThreadsList.jsx";
+import { ThreadsProvider } from "../../demos/comments/React/context.jsx";
+import { useThreads } from "../../demos/comments/React/hooks/useThreads.jsx";
+import { useUser } from "../../demos/comments/React/hooks/useUser.jsx";
+import "../../demos/comments/React/styles.scss";
+import "../../demos/comments/style.scss";
+import "../../styles/tracked-changes.css";
+import { getCollabConfig } from "../server-ai-agent-chatbot/actions";
+
+const INITIAL_CONTENT = `<h1>Grammar Check Demo</h1>
+<p>This is a excelent editor for writng documents. It have many feature's that makes it very powerfull.
+Users can easyly create content, but sometimes they makes small mistake's that are hard to notice.
+The tool also help you to edit faster and more effeciently, althou it not always perfect.
+Its interface are simple, but it contain option's that may confuse new user's at first.</p>`;
+
+type DemoThread = {
+  id: string;
+  resolvedAt?: string | null;
+  data?: {
+    suggestionId?: string;
+    suggestionReason?: string;
+  };
+};
+
+export default function Page() {
+  const [isMounted, setIsMounted] = useState(false);
+  const [doc] = useState(() => new Y.Doc());
+  const [documentId] = useState(
+    () => `server-proofreader-workflow-tracked-comments/${uuid()}`,
+  );
+  const [provider, setProvider] = useState<TiptapCollabProvider | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+
+    let collabProvider: TiptapCollabProvider | null = null;
+
+    const setupProvider = async () => {
+      try {
+        const { token, appId, collabBaseUrl } = await getCollabConfig(
+          "user-1",
+          documentId,
+        );
+
+        collabProvider = new TiptapCollabProvider({
+          ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
+          name: documentId,
+          token,
+          document: doc,
+          user: "user-1",
+        });
+
+        setProvider(collabProvider);
+      } catch (error) {
+        console.error("Failed to setup collaboration:", error);
+      }
+    };
+
+    setupProvider();
+
+    return () => {
+      collabProvider?.destroy();
+    };
+  }, [documentId, doc, isMounted]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  if (!provider) {
+    return (
+      <div className="tracked-changes-comments-demo flex h-screen items-center justify-center bg-white">
+        <div className="space-y-2 text-center">
+          <div className="label-large">Loading collaboration document</div>
+          <p className="label-small text-slate-500">
+            Mounting the comments provider before the editor initializes.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <ProofreaderCommentsEditor
+      doc={doc}
+      documentId={documentId}
+      provider={provider}
+    />
+  );
+}
+
+type ProofreaderCommentsEditorProps = {
+  doc: Y.Doc;
+  documentId: string;
+  provider: TiptapCollabProvider;
+};
+
+function ProofreaderCommentsEditor({
+  doc,
+  documentId,
+  provider,
+}: ProofreaderCommentsEditorProps) {
+  const user = useUser();
+  const [hasSuggestions, setHasSuggestions] = useState(false);
+  const [selectedThread, setSelectedThread] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+
+  const editor = useEditor({
+    immediatelyRender: false,
+    extensions: [
+      StarterKit.configure({
+        undoRedo: false,
+      }),
+      Collaboration.configure({
+        document: doc,
+      }),
+      ServerAiToolkit,
+      TrackedChanges.configure({
+        enabled: false,
+      }),
+      CommentsKit.configure({
+        provider,
+        onClickThread: (threadId: string | null) => {
+          if (!threadId) {
+            setSelectedThread(null);
+            editor?.chain().unselectThread().run();
+            return;
+          }
+
+          setSelectedThread(threadId);
+          editor
+            ?.chain()
+            .selectThread({ id: threadId, updateSelection: false })
+            .run();
+        },
+      }),
+    ],
+    editorProps: {
+      attributes: {
+        // @ts-expect-error spellcheck is a valid DOM attribute
+        spellcheck: false,
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (!editor || !provider) {
+      return;
+    }
+
+    const handleSync = () => {
+      if (editor.isEmpty) {
+        editor.commands.setContent(INITIAL_CONTENT);
+      }
+    };
+
+    if (provider.isSynced) {
+      handleSync();
+    } else {
+      provider.on("synced", handleSync);
+    }
+
+    return () => {
+      provider.off("synced", handleSync);
+    };
+  }, [editor, provider]);
+
+  const threadsResult = useThreads(provider, editor, user);
+  const threads: DemoThread[] = Array.isArray(threadsResult.threads)
+    ? threadsResult.threads
+    : [];
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const updateSuggestionState = () => {
+      setHasSuggestions(findSuggestions(editor, "suggestion").length > 0);
+    };
+
+    updateSuggestionState();
+    editor.on("transaction", updateSuggestionState);
+
+    return () => {
+      editor.off("transaction", updateSuggestionState);
+    };
+  }, [editor]);
+
+  const selectThreadInEditor = useCallback(
+    (threadId: string) => {
+      editor?.chain().selectThread({ id: threadId }).run();
+    },
+    [editor],
+  );
+
+  const deleteThread = useCallback(
+    (threadId: string) => {
+      provider.deleteThread(threadId);
+      editor?.commands.removeThread({ id: threadId });
+    },
+    [editor, provider],
+  );
+
+  const resolveThread = useCallback(
+    (threadId: string) => {
+      editor?.commands.resolveThread({ id: threadId });
+    },
+    [editor],
+  );
+
+  const unresolveThread = useCallback(
+    (threadId: string) => {
+      editor?.commands.unresolveThread({ id: threadId });
+    },
+    [editor],
+  );
+
+  const updateComment = useCallback(
+    (
+      threadId: string,
+      commentId: string,
+      content: string,
+      metaData: Record<string, string>,
+    ) => {
+      editor?.commands.updateComment({
+        threadId,
+        id: commentId,
+        content,
+        data: metaData,
+      });
+    },
+    [editor],
+  );
+
+  const onHoverThread = useCallback(
+    (threadId: number) => {
+      if (!editor) {
+        return;
+      }
+      // hoverThread / hoverOffThread read editor history state, which is null
+      // when StarterKit's `undoRedo` extension is disabled (the established
+      // demo pattern). The hover effect is purely visual, so failures here
+      // are safe to swallow.
+      try {
+        hoverThread(editor, [threadId]);
+      } catch {
+        // best-effort
+      }
+    },
+    [editor],
+  );
+
+  const onLeaveThread = useCallback(() => {
+    if (!editor) {
+      return;
+    }
+    try {
+      hoverOffThread(editor);
+    } catch {
+      // best-effort
+    }
+  }, [editor]);
+
+  if (!editor) {
+    return null;
+  }
+
+  const runProofreader = async () => {
+    setIsLoading(true);
+
+    try {
+      const response = await fetch(
+        "/api/server-proofreader-workflow-tracked-comments",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            documentId,
+            schemaAwarenessData: getSchemaAwarenessData(editor),
+            sessionId,
+          }),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP error ${response.status}`);
+      }
+
+      const result: { sessionId: string } = await response.json();
+      setSessionId(result.sessionId);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const openThreads = threads.filter((thread) => !thread.resolvedAt);
+
+  return (
+    <ThreadsProvider
+      // @ts-expect-error JSX interop with JS comments demo code
+      onClickThread={selectThreadInEditor}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onDeleteThread={deleteThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onHoverThread={onHoverThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onLeaveThread={onLeaveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onResolveThread={resolveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onUpdateComment={updateComment}
+      // @ts-expect-error JSX interop with JS comments demo code
+      onUnresolveThread={unresolveThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      selectedThreads={editor.storage.comments?.focusedThreads ?? []}
+      // @ts-expect-error JSX interop with JS comments demo code
+      selectedThread={selectedThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      setSelectedThread={setSelectedThread}
+      // @ts-expect-error JSX interop with JS comments demo code
+      threads={threads}
+    >
+      <div className="tracked-changes-comments-demo flex flex-col h-screen">
+        <ToolbarPanel>
+          {!hasSuggestions ? (
+            <button
+              type="button"
+              onClick={runProofreader}
+              disabled={isLoading}
+              className="inline-flex items-center gap-1.5 rounded-lg border-none bg-[var(--gray-2)] text-[var(--black)] px-2.5 py-1.5 text-sm font-medium hover:bg-[var(--gray-3)] disabled:bg-[var(--gray-1)] disabled:text-[var(--gray-4)] transition-all duration-200 cursor-pointer disabled:cursor-not-allowed"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="animate-spin" size={14} /> Checking...
+                </>
+              ) : (
+                "Check Grammar"
+              )}
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => {
+                  editor.commands.acceptAllSuggestions();
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--green)] text-white hover:opacity-90 transition-all duration-200 cursor-pointer"
+              >
+                Accept all
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  editor.commands.rejectAllSuggestions();
+                }}
+                className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium bg-[var(--gray-2)] text-[var(--black)] hover:bg-[var(--gray-3)] transition-all duration-200 cursor-pointer"
+              >
+                Reject all
+              </button>
+            </>
+          )}
+        </ToolbarPanel>
+        <div
+          className="col-group divide-x divide-gray-200 flex-1 overflow-hidden"
+          data-viewmode="open"
+        >
+          <aside className="sidebar border-r border-gray-200 bg-white">
+            <div className="space-y-3">
+              <div>
+                <div className="label-large">Comments</div>
+                <p className="label-small mt-1">
+                  Each AI correction's justification becomes a comment thread
+                  linked to its tracked change.
+                </p>
+              </div>
+              <ThreadsList provider={provider} threads={openThreads} />
+            </div>
+          </aside>
+
+          <div className="main overflow-y-auto">
+            <EditorContent editor={editor} />
+          </div>
+        </div>
+      </div>
+    </ThreadsProvider>
+  );
+}

--- a/src/lib/server-ai-toolkit/workflow-api.ts
+++ b/src/lib/server-ai-toolkit/workflow-api.ts
@@ -106,12 +106,16 @@ async function postWorkflowRequest<TResponse>(
 export async function getWorkflowDefinition(
   name: "edit" | "insert-content" | "proofreader" | "threads",
   format: WorkflowFormat,
+  options?: {
+    operationMeta?: string;
+  },
 ) {
   return postWorkflowRequest<{
     systemPrompt: string;
     outputSchema: Record<string, unknown>;
   }>(`/toolkit/workflows/${name}`, {
     format,
+    ...(options?.operationMeta ? { operationMeta: options.operationMeta } : {}),
   });
 }
 
@@ -188,6 +192,10 @@ export async function executeWorkflowEdit(
     input: unknown;
     sessionId?: string | null;
     reviewOptions?: ReviewOptions;
+    experimental_commentsOptions?: {
+      threadData?: Record<string, unknown>;
+      commentData?: Record<string, unknown>;
+    };
   } & DocumentSource,
 ) {
   return postWorkflowRequest<{
@@ -213,6 +221,10 @@ export async function executeWorkflowProofreader(
     sessionId?: string | null;
     reviewOptions?: ReviewOptions;
     format: "shorthand";
+    experimental_commentsOptions?: {
+      threadData?: Record<string, unknown>;
+      commentData?: Record<string, unknown>;
+    };
   } & DocumentSource,
 ) {
   return postWorkflowRequest<{


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE YET** — this PR depends on a Server AI Toolkit fix (`operationMeta` support for the edit and proofreader workflows) being merged and deployed to production first. Without it, the comment threads created in production will be empty (no AI justifications). Merge order: Server AI Toolkit fix → wait for prod deploy → this PR.

## Summary

Adds two new Server AI Toolkit workflow demos that combine tracked changes with linked comment threads:

- `/server-edit-workflow-tracked-comments` — Tiptap Edit workflow with tracked changes + AI justification comments
- `/server-proofreader-workflow-tracked-comments` — Proofreader workflow with the same setup

Each AI edit operation gets a justification (via the new `operationMeta` workflow option), and that justification becomes the content of a comment thread linked to its tracked change.

## Changes

**New routes & pages:**
- `app/api/server-edit-workflow-tracked-comments/route.ts`
- `app/server-edit-workflow-tracked-comments/page.tsx`
- `app/api/server-proofreader-workflow-tracked-comments/route.ts`
- `app/server-proofreader-workflow-tracked-comments/page.tsx`

**Wrapper extensions** (`lib/server-ai-toolkit/workflow-api.ts`):
- `getWorkflowDefinition` now accepts an `operationMeta` option
- `executeWorkflowEdit` and `executeWorkflowProofreader` now accept `experimental_commentsOptions`

**Home page** (`app/page.tsx`):
- "Server Edit + Tracked + Comments" entry under Workflows
- "Server Proofreader + Tracked + Comments" entry under Workflows

## Pattern reference

Follows the existing `server-ai-tracked-changes-comments` agent demo pattern (TrackedChanges + CommentsKit + ThreadsList sidebar), adapted to the workflow style (textarea/button instead of chat sidebar).

## Known limitations (acknowledged, not blockers for this PR)

- AI may produce non-unique justifications when splitting a paragraph into multiple operations. This is a prompt-tuning concern (`OPERATION_META_DESCRIPTION` constant in each route), not a system issue. Production users should iterate on the meta description for their use case.
- `hoverThread` / `hoverOffThread` from `@tiptap-pro/extension-comments` throw on `historyState` null when StarterKit's `undoRedo` is disabled (the established demo pattern). Wrapped in try/catch as a best-effort workaround. The same bug affects the existing `server-ai-tracked-changes-comments` demo and should be fixed in the package.

## Test plan

- [ ] Merge **after** the Server AI Toolkit \`operationMeta\` fix lands in production
- [ ] \`pnpm lint\` passes
- [ ] \`/server-edit-workflow-tracked-comments\`:
  - Document loads
  - "Edit Document" produces tracked changes (green/red marks)
  - Sidebar shows threads with AI justifications (not empty)
  - Accept all / Reject all work
- [ ] \`/server-proofreader-workflow-tracked-comments\`:
  - Document loads with grammar mistakes
  - "Check Grammar" produces tracked changes
  - Sidebar shows threads with corrections explained
  - Accept all / Reject all work
- [ ] Home page entries discoverable under Server AI Toolkit > Workflows