### PR TITLE
fix: use the Document Server app id for the collab provider, not the environment id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ TIPTAP_CLOUD_AI_API_URL=https://api.tiptap.dev
 # Used to mint JWTs for Server AI Toolkit and Collaboration.
 TIPTAP_AUTH_PRIVATE_KEY=your-es256-private-key-pem
 TIPTAP_AUTH_ENVIRONMENT_ID=env_your-environment-id
+# Document Server app id (Tiptap Cloud dashboard). Routes the Collaboration
+# WebSocket. Distinct from TIPTAP_AUTH_ENVIRONMENT_ID, which only signs the token.
+TIPTAP_CLOUD_DOCUMENT_SERVER_ID=your-document-server-app-id
 
 # Optionally overwrite the base URL for an on-prem Collaboration instance.
 # TIPTAP_CLOUD_COLLAB_BASE_URL=https://your-on-prem-instance.com

--- a/src/app/server-ai-agent-chatbot/actions.ts
+++ b/src/app/server-ai-agent-chatbot/actions.ts
@@ -8,6 +8,10 @@ export async function getCollabConfig(
 ): Promise<{ token: string; appId: string; collabBaseUrl?: string }> {
   const privateKey = process.env.TIPTAP_AUTH_PRIVATE_KEY?.replace(/\\n/g, "\n");
   const environmentId = process.env.TIPTAP_AUTH_ENVIRONMENT_ID;
+  // The collab provider routes by the Document Server app id, not the TAC
+  // environment id: the environment id only signs the token (issuer), while the
+  // WebSocket connects to `<documentServerId>.collab.tiptap.cloud`.
+  const documentServerId = process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID;
   const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
 
   if (!privateKey) {
@@ -17,6 +21,12 @@ export async function getCollabConfig(
   if (!environmentId) {
     throw new Error(
       "TIPTAP_AUTH_ENVIRONMENT_ID environment variable is not set",
+    );
+  }
+
+  if (!documentServerId) {
+    throw new Error(
+      "TIPTAP_CLOUD_DOCUMENT_SERVER_ID environment variable is not set",
     );
   }
 
@@ -36,7 +46,7 @@ export async function getCollabConfig(
 
   return {
     token,
-    appId: environmentId,
+    appId: documentServerId,
     collabBaseUrl,
   };
 }

--- a/src/app/server-comments/actions.ts
+++ b/src/app/server-comments/actions.ts
@@ -8,6 +8,10 @@ export async function getCollabConfig(
 ): Promise<{ token: string; appId: string; collabBaseUrl?: string }> {
   const privateKey = process.env.TIPTAP_AUTH_PRIVATE_KEY?.replace(/\\n/g, "\n");
   const environmentId = process.env.TIPTAP_AUTH_ENVIRONMENT_ID;
+  // The collab provider routes by the Document Server app id, not the TAC
+  // environment id: the environment id only signs the token (issuer), while the
+  // WebSocket connects to `<documentServerId>.collab.tiptap.cloud`.
+  const documentServerId = process.env.TIPTAP_CLOUD_DOCUMENT_SERVER_ID;
   const collabBaseUrl = process.env.TIPTAP_CLOUD_COLLAB_BASE_URL;
 
   if (!privateKey) {
@@ -17,6 +21,12 @@ export async function getCollabConfig(
   if (!environmentId) {
     throw new Error(
       "TIPTAP_AUTH_ENVIRONMENT_ID environment variable is not set",
+    );
+  }
+
+  if (!documentServerId) {
+    throw new Error(
+      "TIPTAP_CLOUD_DOCUMENT_SERVER_ID environment variable is not set",
     );
   }
 
@@ -36,7 +46,7 @@ export async function getCollabConfig(
 
   return {
     token,
-    appId: environmentId,
+    appId: documentServerId,
     collabBaseUrl,
   };
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -20,6 +20,9 @@ declare global {
       TIPTAP_CLOUD_AI_API_URL?: string;
       TIPTAP_AUTH_PRIVATE_KEY?: string;
       TIPTAP_AUTH_ENVIRONMENT_ID?: string;
+      // Document Server app id: routes the Collaboration WebSocket (distinct
+      // from the environment id, which only signs the token).
+      TIPTAP_CLOUD_DOCUMENT_SERVER_ID?: string;
       TIPTAP_CLOUD_COLLAB_BASE_URL?: string;
     }
   }


### PR DESCRIPTION
## Problem

`getCollabConfig` returned `appId: environmentId`, so the browser connected to
`<environmentId>.collab.tiptap.cloud` (invalid) and Collaboration auth broke in the new TAC
demos. The environment id only signs the token (issuer); the collab WebSocket must route by
the Document Server app id.

## Fix

`appId` now comes from `TIPTAP_CLOUD_DOCUMENT_SERVER_ID` (ES256 token unchanged), in both
`getCollabConfig` copies (`server-ai-agent-chatbot` + `server-comments`). Re-added the var to
`.env.example` and the env types.

## Testing

All server demos verified locally (chatbot, tracked changes, streaming, comments); biome + tsc clean.

