### PR TITLE
Revert "Add collab rest api permissions"

### DIFF
--- a/src/lib/server-ai-toolkit/get-tiptap-cloud-ai-jwt-token.ts
+++ b/src/lib/server-ai-toolkit/get-tiptap-cloud-ai-jwt-token.ts
@@ -1,7 +1,7 @@
 import jwt from "jsonwebtoken";
 
 type TiptapAccessPermission = {
-  action: "AI:Toolkit" | "Documents:Write" | "Documents:Api:All";
+  action: "AI:Toolkit" | "Documents:Write";
   resource: string;
 };
 
@@ -39,16 +39,10 @@ export function getTiptapCloudAiJwtToken(
   ];
 
   if (options.documentId) {
-    permissions.push(
-      {
-        action: "Documents:Write",
-        resource: options.documentId,
-      },
-      {
-        action: "Documents:Api:All",
-        resource: "*",
-      },
-    );
+    permissions.push({
+      action: "Documents:Write",
+      resource: options.documentId,
+    });
   }
 
   return jwt.sign({ permissions }, privateKey, {


### PR DESCRIPTION
Now that the AI Server has been configured to connect to the document server with the web socket connection instead of using the document REST API, we no longer have to set the Documents:Api:All permission when configuring the JWT

Reverts ueberdosis/ai-toolkit-demos#88