### PR TITLE
feat: add server stream-tool streaming demos with http/2 client for proxy duplex

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Server-side AI toolkit demos that run AI operations on the server for enhanced s
 
 - **Server AI Agent Chatbot** (`/server-ai-agent-chatbot`) - A server-side AI agent that can edit collaborative documents
 - **Server Comments** (`/server-comments`) - A server-side AI agent that can add and manage comments via Tiptap Collaboration
+- **Server Stream Tool** (`/server-ai-stream-tool-chatbot`) - Streams a `tiptapEdit` tool call to the server so edits appear live, character by character
+- **Server Stream Tool (Tracked Changes)** (`/server-ai-stream-tool-chatbot-tracked-changes`) - Same streaming flow with tracked-changes mode, so edits arrive as accept/reject suggestions
 
 ## Tech Stack
 

--- a/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
@@ -1,0 +1,324 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import {
+  gateway,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+  wrapLanguageModel,
+} from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getTiptapCloudAiJwtToken } from "@/lib/server-ai-toolkit/get-tiptap-cloud-ai-jwt-token";
+import { streamToolFetch } from "@/lib/server-ai-toolkit/stream-tool-fetch";
+
+// Duplex request-body streaming requires the Node.js runtime (not Edge). Raise the
+// function timeout so a long, paced AI edit isn't cut off by the platform default.
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * Tracked-changes variant of the LLM-driven `/stream-tool` bridge.
+ *
+ * Identical to `server-ai-stream-tool-chatbot` except the `start` message
+ * carries `reviewOptions: { mode: "trackedChanges" }`, so the AI server
+ * applies the streamed edit as a tracked-change suggestion (old content kept
+ * red, new content typed into the green area, sharing one suggestion id)
+ * instead of mutating the document in place. The editor renders the
+ * suggestion live via Y.Doc sync and can accept/reject it.
+ *
+ *   browser → this route → POST /v3/toolkit/tools                       (prompt + tool defs)
+ *                       → POST /v3/toolkit/execute-tool                 (readDocument tool — fetches via WS session)
+ *                       → LLM via streamText({tools:{tiptapEdit:tool(...)}})
+ *                          - tool.onInputDelta → /stream-tool `delta` msg
+ *                       → AI server's NDJSON response → browser
+ */
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+  }
+
+  const {
+    messages,
+    editorContext,
+    documentId,
+    userId,
+  }: {
+    messages: UIMessage[];
+    editorContext: unknown;
+    documentId: string;
+    userId?: string;
+  } = await req.json();
+
+  // Single-shot streaming edit: the task is the latest user message.
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((m) => m.role === "user");
+  const task =
+    lastUserMessage?.parts
+      ?.filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join(" ")
+      .trim() ?? "";
+  // Internal alias: the rest of the route already speaks `schemaAwarenessData`.
+  const schemaAwarenessData = editorContext;
+
+  if (!task || !schemaAwarenessData || !documentId) {
+    return new Response(
+      JSON.stringify({
+        error: "Missing required fields: messages, editorContext, documentId",
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const apiBaseUrl =
+    process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev";
+  const tiptapCloudAiJwtToken = getTiptapCloudAiJwtToken({ documentId });
+
+  // 1) Single canonical call: `/tools` returns both the schema-awareness
+  //    prompt and the tool definitions in one round-trip. `format: "json"`
+  //    is required because `/stream-tool`'s processor parses content as an
+  //    array of ProseMirror JSON nodes — shorthand strings wouldn't stream
+  //    into individual createNode/appendText actions.
+  type ToolsResponse = {
+    tools: Array<{
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+    }>;
+    prompt: string;
+  };
+  let toolsResponse: ToolsResponse;
+  try {
+    const fetchResult = await fetch(`${apiBaseUrl}/v3/ai/toolkit/tools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: JSON.stringify({
+        editorContext: schemaAwarenessData,
+        tools: { tiptapEdit: true },
+        format: "json",
+      }),
+    });
+    if (!fetchResult.ok) {
+      throw new Error(`${fetchResult.status} ${fetchResult.statusText}`);
+    }
+    toolsResponse = (await fetchResult.json()) as ToolsResponse;
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `Failed to fetch tools: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const tiptapEditTool = toolsResponse.tools.find(
+    (t) => t.name === "tiptapEdit",
+  );
+  if (!tiptapEditTool) {
+    return new Response(
+      JSON.stringify({
+        error: "Server /tools response did not include the tiptapEdit tool",
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // 2) Read the document via the `readDocument` tool through /execute-tool.
+  //    This goes through the session-backed DocumentProvider, which opens a
+  //    WebSocket session against Tiptap Cloud Hocuspocus — bypassing the
+  //    Document API REST surface that requires a wider JWT scope than the
+  //    customer's multi-aud token typically carries.
+  let documentContent: unknown;
+  try {
+    const readResult = await fetch(`${apiBaseUrl}/v3/ai/toolkit/execute-tool`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: JSON.stringify({
+        toolName: "readDocument",
+        input: {},
+        editorContext: schemaAwarenessData,
+        experimental_documentOptions: {
+          documentId,
+          userId: userId ?? "ai-assistant",
+        },
+        format: "json",
+      }),
+    });
+    if (!readResult.ok) {
+      const errorText = await readResult.text();
+      throw new Error(
+        `${readResult.status} ${readResult.statusText}${errorText ? ` - ${errorText}` : ""}`,
+      );
+    }
+    const readJson = (await readResult.json()) as {
+      toolResult?: { success?: boolean; content?: unknown; error?: string };
+    };
+    if (!readJson.toolResult?.success || !readJson.toolResult.content) {
+      throw new Error(
+        readJson.toolResult?.error ?? "readDocument tool returned no content",
+      );
+    }
+    documentContent = readJson.toolResult.content;
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `readDocument tool failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // 3) Build the NDJSON request body driven by the tool's onInput* callbacks.
+  const encoder = new TextEncoder();
+  // Ref so TS doesn't narrow the controller binding to `null` through
+  // the closure assignment in `start()`.
+  const controllerRef: {
+    current: ReadableStreamDefaultController<Uint8Array> | null;
+  } = { current: null };
+  const ndjsonRequestBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef.current = controller;
+    },
+  });
+  let forwardedStart = false;
+  let forwardedEnd = false;
+
+  const writeNdjson = (payload: Record<string, unknown>) => {
+    if (!controllerRef.current) return;
+    controllerRef.current.enqueue(
+      encoder.encode(`${JSON.stringify(payload)}\n`),
+    );
+  };
+
+  // Streams the request body while reading the response (full-duplex), forced
+  // over HTTP/2 so a reverse proxy does not truncate the upload. See streamToolFetch.
+  const upstreamPromise = streamToolFetch(
+    `${apiBaseUrl}/v3/ai/toolkit/stream-tool`,
+    {
+      method: "POST",
+      duplex: "half",
+      headers: {
+        "Content-Type": "application/x-ndjson",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: ndjsonRequestBody,
+    },
+  );
+
+  // 4) LLM call. The tool uses `tiptapEdit`'s canonical inputSchema (now
+  //    strict — `content` items cannot carry operation keywords as their
+  //    `type`, see ai-server `createTiptapEditSchema`). The `onInputDelta`
+  //    callback yields raw text deltas as the model generates them —
+  //    which is what `/stream-tool` expects.
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const llmResult = streamText({
+    model,
+    system: `You are an expert editor that edits rich text documents using the tiptapEdit tool. You will be given a document and a task. Call tiptapEdit exactly once to make the edit, then reply with one short sentence confirming what you changed and letting the user know they can review it in the Tracked changes tab. Do not include document contents, hashes, or operation details in your reply.\n\n${toolsResponse.prompt}`,
+    prompt: JSON.stringify({ content: documentContent, task }),
+    tools: {
+      tiptapEdit: tool({
+        description: tiptapEditTool.description,
+        inputSchema: z.fromJSONSchema(
+          tiptapEditTool.inputSchema as z.core.JSONSchema.JSONSchema,
+        ),
+        // Force OpenAI structured-outputs constrained sampling so the
+        // `inputSchema` enum on `content[].type` is enforced at token level
+        // (not just sent as a hint). Without this flag, the LLM has been
+        // observed bypassing the enum and nesting operations into content.
+        // See `@ai-sdk/openai`'s `prepareChatTools` — `strict` is only
+        // forwarded when explicitly set; OpenAI defaults to false otherwise.
+        strict: true,
+        onInputStart: () => {
+          if (forwardedStart) return;
+          forwardedStart = true;
+          writeNdjson({
+            version: 1,
+            type: "start",
+            toolName: "tiptapEdit",
+            editorContext: schemaAwarenessData,
+            experimental_documentOptions: {
+              documentId,
+              userId: userId ?? "ai-assistant",
+            },
+            // Tracked-changes mode: the AI server keeps the old content as a
+            // red `replaceDeletion` and types the new content into a green
+            // `replaceInsertion`, sharing one suggestion id. The suggestion
+            // author is `trackedChangesOptions.userId`.
+            reviewOptions: {
+              mode: "trackedChanges",
+              trackedChangesOptions: {
+                userId: userId ?? "ai-assistant",
+                userMetadata: { name: "AI" },
+              },
+            },
+          });
+        },
+        onInputDelta: ({ inputTextDelta }) => {
+          if (!forwardedStart || forwardedEnd) return;
+          if (!inputTextDelta) return;
+          writeNdjson({
+            version: 1,
+            type: "delta",
+            argsTextDelta: inputTextDelta,
+          });
+        },
+        onInputAvailable: () => {
+          if (forwardedEnd) return;
+          forwardedEnd = true;
+          writeNdjson({ version: 1, type: "end" });
+          controllerRef.current?.close();
+          controllerRef.current = null;
+        },
+        // Drive the /stream-tool bridge to completion and report a result so the
+        // useChat turn finishes. The edit reaches the editor via Y.Doc sync, not
+        // through this value.
+        execute: async () => {
+          const upstream = await upstreamPromise;
+          await upstream.text();
+          return { ok: upstream.ok };
+        },
+      }),
+    },
+    // Step 0: force the edit so the typing effect always happens. Step 1: forbid
+    // tools so the model writes a short confirmation sentence for the chat.
+    stopWhen: stepCountIs(2),
+    prepareStep: ({ stepNumber }) => ({
+      toolChoice: stepNumber === 0 ? "required" : "none",
+    }),
+    providerOptions: {
+      openai: { reasoningEffort: "low" },
+    },
+  });
+
+  // Return a UI message stream so the client uses `useChat`, exactly like the
+  // non-streaming server demos. The tiptapEdit tool's `execute` drives the
+  // /stream-tool bridge; the streamed edits reach the editor via Y.Doc sync.
+  return llmResult.toUIMessageStreamResponse();
+}

--- a/src/app/api/server-ai-stream-tool-chatbot/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot/route.ts
@@ -1,0 +1,313 @@
+import { devToolsMiddleware } from "@ai-sdk/devtools";
+import {
+  gateway,
+  stepCountIs,
+  streamText,
+  tool,
+  type UIMessage,
+  wrapLanguageModel,
+} from "ai";
+import z from "zod";
+import { getIp, rateLimit } from "@/lib/rate-limit";
+import { getTiptapCloudAiJwtToken } from "@/lib/server-ai-toolkit/get-tiptap-cloud-ai-jwt-token";
+import { streamToolFetch } from "@/lib/server-ai-toolkit/stream-tool-fetch";
+
+// Duplex request-body streaming requires the Node.js runtime (not Edge). Raise the
+// function timeout so a long, paced AI edit isn't cut off by the platform default.
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+/**
+ * LLM-driven bridge to the AI server's `/stream-tool` endpoint.
+ *
+ *   browser → this route → POST /v3/toolkit/tools                       (prompt + tool defs)
+ *                       → POST /v3/toolkit/execute-tool                 (readDocument tool — fetches via WS session)
+ *                       → LLM via streamText({tools:{tiptapEdit:tool(...)}})
+ *                          - tool.inputSchema  = tiptapEdit.inputSchema from /tools
+ *                          - tool.description  = tiptapEdit.description from /tools
+ *                          - tool.onInputDelta → /stream-tool `delta` msg
+ *                       → AI server's NDJSON response → browser log panel
+ *
+ * Document content is fetched via the `readDocument` tool through
+ * `/execute-tool` instead of the legacy `/read-document` REST endpoint —
+ * the tool flows through the session-backed DocumentProvider, so it doesn't
+ * hit the Document API REST surface (which has stricter scope requirements
+ * for the customer's multi-aud JWT).
+ *
+ * Streaming wire format unchanged: each `onInputDelta` callback forwards
+ * raw `argsTextDelta` text to `/stream-tool` as NDJSON.
+ */
+export async function POST(req: Request) {
+  if (process.env.UPSTASH_REDIS_REST_URL) {
+    const ip = await getIp();
+    const isAllowed = await rateLimit(ip);
+    if (!isAllowed) {
+      return new Response("Rate limit exceeded. Please try again later.", {
+        status: 429,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+  }
+
+  const {
+    messages,
+    editorContext,
+    documentId,
+    userId,
+  }: {
+    messages: UIMessage[];
+    editorContext: unknown;
+    documentId: string;
+    userId?: string;
+  } = await req.json();
+
+  // Single-shot streaming edit: the task is the latest user message.
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((m) => m.role === "user");
+  const task =
+    lastUserMessage?.parts
+      ?.filter((p) => p.type === "text")
+      .map((p) => (p as { text: string }).text)
+      .join(" ")
+      .trim() ?? "";
+  // Internal alias: the rest of the route already speaks `schemaAwarenessData`.
+  const schemaAwarenessData = editorContext;
+
+  if (!task || !schemaAwarenessData || !documentId) {
+    return new Response(
+      JSON.stringify({
+        error: "Missing required fields: messages, editorContext, documentId",
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const apiBaseUrl =
+    process.env.TIPTAP_CLOUD_AI_API_URL || "https://api.tiptap.dev";
+  const tiptapCloudAiJwtToken = getTiptapCloudAiJwtToken({ documentId });
+
+  // 1) Single canonical call: `/tools` returns both the schema-awareness
+  //    prompt and the tool definitions in one round-trip. `format: "json"`
+  //    is required because `/stream-tool`'s processor parses content as an
+  //    array of ProseMirror JSON nodes — shorthand strings wouldn't stream
+  //    into individual createNode/appendText actions.
+  type ToolsResponse = {
+    tools: Array<{
+      name: string;
+      description: string;
+      inputSchema: Record<string, unknown>;
+    }>;
+    prompt: string;
+  };
+  let toolsResponse: ToolsResponse;
+  try {
+    const fetchResult = await fetch(`${apiBaseUrl}/v3/ai/toolkit/tools`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: JSON.stringify({
+        editorContext: schemaAwarenessData,
+        tools: { tiptapEdit: true },
+        format: "json",
+      }),
+    });
+    if (!fetchResult.ok) {
+      throw new Error(`${fetchResult.status} ${fetchResult.statusText}`);
+    }
+    toolsResponse = (await fetchResult.json()) as ToolsResponse;
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `Failed to fetch tools: ${err instanceof Error ? err.message : String(err)}`,
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const tiptapEditTool = toolsResponse.tools.find(
+    (t) => t.name === "tiptapEdit",
+  );
+  if (!tiptapEditTool) {
+    return new Response(
+      JSON.stringify({
+        error: "Server /tools response did not include the tiptapEdit tool",
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // 2) Read the document via the `readDocument` tool through /execute-tool.
+  //    This goes through the session-backed DocumentProvider, which opens a
+  //    WebSocket session against Tiptap Cloud Hocuspocus — bypassing the
+  //    Document API REST surface that requires a wider JWT scope than the
+  //    customer's multi-aud token typically carries.
+  let documentContent: unknown;
+  try {
+    const readResult = await fetch(`${apiBaseUrl}/v3/ai/toolkit/execute-tool`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: JSON.stringify({
+        toolName: "readDocument",
+        input: {},
+        editorContext: schemaAwarenessData,
+        experimental_documentOptions: {
+          documentId,
+          userId: userId ?? "ai-assistant",
+        },
+        format: "json",
+      }),
+    });
+    if (!readResult.ok) {
+      const errorText = await readResult.text();
+      throw new Error(
+        `${readResult.status} ${readResult.statusText}${errorText ? ` - ${errorText}` : ""}`,
+      );
+    }
+    const readJson = (await readResult.json()) as {
+      toolResult?: { success?: boolean; content?: unknown; error?: string };
+    };
+    if (!readJson.toolResult?.success || !readJson.toolResult.content) {
+      throw new Error(
+        readJson.toolResult?.error ?? "readDocument tool returned no content",
+      );
+    }
+    documentContent = readJson.toolResult.content;
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        error: `readDocument tool failed: ${err instanceof Error ? err.message : String(err)}`,
+      }),
+      { status: 502, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // 3) Build the NDJSON request body driven by the tool's onInput* callbacks.
+  const encoder = new TextEncoder();
+  // Ref so TS doesn't narrow the controller binding to `null` through
+  // the closure assignment in `start()`.
+  const controllerRef: {
+    current: ReadableStreamDefaultController<Uint8Array> | null;
+  } = { current: null };
+  const ndjsonRequestBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controllerRef.current = controller;
+    },
+  });
+  let forwardedStart = false;
+  let forwardedEnd = false;
+
+  const writeNdjson = (payload: Record<string, unknown>) => {
+    if (!controllerRef.current) return;
+    controllerRef.current.enqueue(
+      encoder.encode(`${JSON.stringify(payload)}\n`),
+    );
+  };
+
+  // Streams the request body while reading the response (full-duplex), forced
+  // over HTTP/2 so a reverse proxy does not truncate the upload. See streamToolFetch.
+  const upstreamPromise = streamToolFetch(
+    `${apiBaseUrl}/v3/ai/toolkit/stream-tool`,
+    {
+      method: "POST",
+      duplex: "half",
+      headers: {
+        "Content-Type": "application/x-ndjson",
+        Authorization: `Bearer ${tiptapCloudAiJwtToken}`,
+        Origin: "http://localhost:3000",
+      },
+      body: ndjsonRequestBody,
+    },
+  );
+
+  // 4) LLM call. The tool uses `tiptapEdit`'s canonical inputSchema (now
+  //    strict — `content` items cannot carry operation keywords as their
+  //    `type`, see ai-server `createTiptapEditSchema`). The `onInputDelta`
+  //    callback yields raw text deltas as the model generates them —
+  //    which is what `/stream-tool` expects.
+  const model = wrapLanguageModel({
+    model: gateway("openai/gpt-5.4-mini"),
+    middleware:
+      process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
+  });
+
+  const llmResult = streamText({
+    model,
+    system: `You are an expert editor that edits rich text documents using the tiptapEdit tool. You will be given a document and a task. Call tiptapEdit exactly once to make the edit, then reply with one short sentence confirming what you changed. Do not include document contents, hashes, or operation details in your reply.\n\n${toolsResponse.prompt}`,
+    prompt: JSON.stringify({ content: documentContent, task }),
+    tools: {
+      tiptapEdit: tool({
+        description: tiptapEditTool.description,
+        inputSchema: z.fromJSONSchema(
+          tiptapEditTool.inputSchema as z.core.JSONSchema.JSONSchema,
+        ),
+        // Force OpenAI structured-outputs constrained sampling so the
+        // `inputSchema` enum on `content[].type` is enforced at token level
+        // (not just sent as a hint). Without this flag, the LLM has been
+        // observed bypassing the enum and nesting operations into content.
+        // See `@ai-sdk/openai`'s `prepareChatTools` — `strict` is only
+        // forwarded when explicitly set; OpenAI defaults to false otherwise.
+        strict: true,
+        onInputStart: () => {
+          if (forwardedStart) return;
+          forwardedStart = true;
+          writeNdjson({
+            version: 1,
+            type: "start",
+            toolName: "tiptapEdit",
+            editorContext: schemaAwarenessData,
+            experimental_documentOptions: {
+              documentId,
+              userId: userId ?? "ai-assistant",
+            },
+          });
+        },
+        onInputDelta: ({ inputTextDelta }) => {
+          if (!forwardedStart || forwardedEnd) return;
+          if (!inputTextDelta) return;
+          writeNdjson({
+            version: 1,
+            type: "delta",
+            argsTextDelta: inputTextDelta,
+          });
+        },
+        onInputAvailable: () => {
+          if (forwardedEnd) return;
+          forwardedEnd = true;
+          writeNdjson({ version: 1, type: "end" });
+          controllerRef.current?.close();
+          controllerRef.current = null;
+        },
+        // Drive the /stream-tool bridge to completion and report a result so the
+        // useChat turn finishes. The edit reaches the editor via Y.Doc sync, not
+        // through this value.
+        execute: async () => {
+          const upstream = await upstreamPromise;
+          await upstream.text();
+          return { ok: upstream.ok };
+        },
+      }),
+    },
+    // Step 0: force the edit so the typing effect always happens. Step 1: forbid
+    // tools so the model writes a short confirmation sentence for the chat.
+    stopWhen: stepCountIs(2),
+    prepareStep: ({ stepNumber }) => ({
+      toolChoice: stepNumber === 0 ? "required" : "none",
+    }),
+    providerOptions: {
+      openai: { reasoningEffort: "low" },
+    },
+  });
+
+  // Return a UI message stream so the client uses `useChat`, exactly like the
+  // non-streaming server demos. The tiptapEdit tool's `execute` drives the
+  // /stream-tool bridge; the streamed edits reach the editor via Y.Doc sync.
+  return llmResult.toUIMessageStreamResponse();
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -190,6 +190,18 @@ const CATEGORIES = [
             description: "Server-side comment threads stored on Tiptap Cloud",
             href: "/server-comments",
           },
+          {
+            title: "Server Streaming",
+            description:
+              "LLM-driven /stream-tool: type a task, AI streams tiptapEdit args, editor types in real time",
+            href: "/server-ai-stream-tool-chatbot",
+          },
+          {
+            title: "Server Streaming + Tracked Changes",
+            description:
+              "Streaming /stream-tool in tracked-changes mode: the AI edit types into a live red/green suggestion you can accept or reject",
+            href: "/server-ai-stream-tool-chatbot-tracked-changes",
+          },
         ],
       },
     ],

--- a/src/app/server-ai-stream-tool-chatbot-tracked-changes/page.tsx
+++ b/src/app/server-ai-stream-tool-chatbot-tracked-changes/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
+import { EditorContent } from "@tiptap/react";
+import { getEditorContext } from "@tiptap/server-ai-toolkit";
+import StarterKit from "@tiptap/starter-kit";
+import { TrackedChanges } from "@tiptap-pro/extension-tracked-changes";
+import { DefaultChatTransport } from "ai";
+import { type FormEvent, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { SuggestionReviewTooltip } from "@/components/suggestion-review-tooltip";
+import type { PanelId } from "@/demos/server-ai-tracked-changes/panel-id";
+import { RightSidebar } from "@/demos/server-ai-tracked-changes/right-sidebar";
+import { TrackedChangesPanel } from "@/demos/server-ai-tracked-changes/tracked-changes-panel";
+import { useStreamToolEditor } from "@/lib/use-stream-tool-editor";
+import { useSuggestionReview } from "@/lib/use-suggestion-review";
+import "@/styles/tracked-changes.css";
+
+const INITIAL_CONTENT = `<h1>The Quiet Rise of Tiptap</h1>
+<p>Three years ago, the idea of building a production rich-text editor from scratch felt like a fringe experiment. Today, kitchen-table prototypes and weekend hacks turn into shippable Tiptap-based editors in days, with extensions composable enough that small teams can match what used to take a full SaaS suite.</p>
+<h2>The shift in everyday rhythm</h2>
+<p>The most visible change is the disappearance of the editor monolith. Developers compose schemas from individual Tiptap extensions, pull in collaboration cursors, and ship features that once took quarters in a single sprint.</p>
+<h2>What comes next</h2>
+<p>The future is unlikely to be a single dominant editor framework, nor a return to building straight on raw ProseMirror.</p>`;
+
+export default function Page() {
+  // The hook owns the Y.Doc, collab provider, editor, and the AI cursor.
+  const { editor, documentId } = useStreamToolEditor({
+    slug: "server-ai-stream-tool-chatbot-tracked-changes",
+    initialContent: INITIAL_CONTENT,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      // `resizable: false` keeps the default table render path. With
+      // `resizable: true`, prosemirror-tables' columnResizing plugin installs a
+      // custom TableView NodeView that bypasses the extension's renderHTML, so a
+      // node-level tracked-change suggestion's `data-suggestion-*` attrs never
+      // reach the DOM and the table highlight is lost.
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableHeader,
+      TableCell,
+    ],
+    // Render AI edits as tracked changes. `enabled: false` keeps local typing
+    // out of suggestion mode; the AI server writes the suggestion marks/attrs
+    // into the Y.Doc and this extension renders them (red = deletion, green =
+    // insertion) and powers accept/reject.
+    trailingExtensions: [TrackedChanges.configure({ enabled: false })],
+  });
+
+  const { suggestions, tooltipMount } = useSuggestionReview(editor);
+
+  // editorContext for the route, kept in a ref (AI SDK stale-closure, vercel/ai#7819).
+  const editorContext = editor ? getEditorContext(editor) : null;
+  const editorContextRef = useRef(editorContext);
+  editorContextRef.current = editorContext;
+
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({
+      api: "/api/server-ai-stream-tool-chatbot-tracked-changes",
+      body: () => ({
+        editorContext: editorContextRef.current,
+        documentId,
+      }),
+    }),
+  });
+
+  const [input, setInput] = useState(
+    "Replace the last paragraph with a 2-sentence story about hybrid work culture",
+  );
+  const [activePanel, setActivePanel] = useState<PanelId>("chat");
+
+  const isLoading = status !== "ready";
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (input.trim() && !isLoading) {
+      sendMessage({ text: input });
+      setInput("");
+      setActivePanel("chat");
+    }
+  };
+
+  if (!editor) return null;
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+        {tooltipMount &&
+          createPortal(
+            <SuggestionReviewTooltip
+              referenceElement={tooltipMount.element}
+              text={tooltipMount.text}
+              onAccept={() => {
+                editor.commands.acceptSuggestion({
+                  id: tooltipMount.suggestionId,
+                });
+              }}
+              onReject={() => {
+                editor.commands.rejectSuggestion({
+                  id: tooltipMount.suggestionId,
+                });
+              }}
+            />,
+            tooltipMount.element,
+          )}
+      </div>
+      <RightSidebar
+        activePanel={activePanel}
+        onActivePanelChange={setActivePanel}
+        messages={messages}
+        input={input}
+        onInputChange={setInput}
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+        trackedPanel={
+          <TrackedChangesPanel editor={editor} suggestions={suggestions} />
+        }
+      />
+    </div>
+  );
+}

--- a/src/app/server-ai-stream-tool-chatbot/page.tsx
+++ b/src/app/server-ai-stream-tool-chatbot/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { Table } from "@tiptap/extension-table";
+import { TableCell } from "@tiptap/extension-table-cell";
+import { TableHeader } from "@tiptap/extension-table-header";
+import { TableRow } from "@tiptap/extension-table-row";
+import { EditorContent } from "@tiptap/react";
+import { getEditorContext } from "@tiptap/server-ai-toolkit";
+import StarterKit from "@tiptap/starter-kit";
+import { DefaultChatTransport } from "ai";
+import { useRef, useState } from "react";
+import { ChatSidebar } from "@/components/chat-sidebar";
+import { useStreamToolEditor } from "@/lib/use-stream-tool-editor";
+
+const INITIAL_CONTENT = `<h1>The Quiet Rise of Tiptap</h1>
+<p>Three years ago, the idea of building a production rich-text editor from scratch felt like a fringe experiment. Today, kitchen-table prototypes and weekend hacks turn into shippable Tiptap-based editors in days, with extensions composable enough that small teams can match what used to take a full SaaS suite.</p>
+<h2>The shift in everyday rhythm</h2>
+<p>The most visible change is the disappearance of the editor monolith. Developers compose schemas from individual Tiptap extensions, pull in collaboration cursors, and ship features that once took quarters in a single sprint.</p>
+<h2>What comes next</h2>
+<p>The future is unlikely to be a single dominant editor framework, nor a return to building straight on raw ProseMirror.</p>`;
+
+export default function Page() {
+  // The hook owns the Y.Doc, collab provider, editor, and the AI cursor
+  // (CollaborationCaret). We only swap the chat over to `useChat`.
+  const { editor, documentId } = useStreamToolEditor({
+    slug: "server-ai-stream-tool-chatbot",
+    initialContent: INITIAL_CONTENT,
+    extensions: [
+      StarterKit.configure({ undoRedo: false }),
+      Table.configure({ resizable: true }),
+      TableRow,
+      TableHeader,
+      TableCell,
+    ],
+  });
+
+  // editorContext for the route, kept in a ref (AI SDK stale-closure, vercel/ai#7819).
+  const editorContext = editor ? getEditorContext(editor) : null;
+  const editorContextRef = useRef(editorContext);
+  editorContextRef.current = editorContext;
+
+  const { messages, sendMessage, status } = useChat({
+    transport: new DefaultChatTransport({
+      api: "/api/server-ai-stream-tool-chatbot",
+      body: () => ({
+        editorContext: editorContextRef.current,
+        documentId,
+      }),
+    }),
+  });
+
+  const [input, setInput] = useState(
+    "Replace the last paragraph with a 2-sentence story about hybrid work culture",
+  );
+
+  const isLoading = status !== "ready";
+
+  const handleSubmit = (e: SubmitEvent) => {
+    e.preventDefault();
+    if (input.trim()) {
+      sendMessage({ text: input });
+      setInput("");
+    }
+  };
+
+  if (!editor) return null;
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex-1 overflow-y-auto">
+        <EditorContent editor={editor} />
+      </div>
+      <ChatSidebar
+        messages={messages}
+        input={input}
+        onInputChange={setInput}
+        onSubmit={handleSubmit}
+        isLoading={isLoading}
+        placeholder="Ask the AI to edit the document..."
+      />
+    </div>
+  );
+}

--- a/src/lib/server-ai-toolkit/stream-tool-fetch.ts
+++ b/src/lib/server-ai-toolkit/stream-tool-fetch.ts
@@ -1,0 +1,150 @@
+import { type ClientHttp2Stream, connect } from "node:http2";
+
+/**
+ * Response shape the `/stream-tool` routes consume: they read `ok`/`status` and
+ * the full body via `text()`.
+ */
+export type StreamToolResponse = {
+  ok: boolean;
+  status: number;
+  /** Resolves the full NDJSON response body once the upstream stream ends. */
+  text: () => Promise<string>;
+};
+
+/**
+ * Fetch-like init for the streaming bridge. `body` is the NDJSON request stream;
+ * `duplex: "half"` is required by the plain-HTTP fallback so the body streams
+ * while the response is read.
+ */
+type StreamToolInit = {
+  method?: string;
+  headers?: HeadersInit;
+  body: ReadableStream<Uint8Array>;
+  duplex?: "half";
+};
+
+/**
+ * Streams a Web `ReadableStream` request body into an HTTP/2 request stream and
+ * ends the request when the body closes. Runs concurrently with reading the
+ * response, which is what keeps the exchange full-duplex. Destroys the request
+ * on a read error rather than leaving it half-open.
+ */
+async function pumpRequestBody(
+  body: ReadableStream<Uint8Array>,
+  req: ClientHttp2Stream,
+): Promise<void> {
+  const reader = body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      req.write(Buffer.from(value));
+    }
+    req.end();
+  } catch (err) {
+    req.destroy(err as Error);
+  }
+}
+
+/**
+ * Issues the `/stream-tool` POST over HTTP/2 with Node's stable `node:http2`
+ * client. The request body streams in while the response is collected, so the
+ * exchange stays full-duplex and a reverse proxy cannot truncate the upload.
+ * Verifies the server's TLS certificate (default), so it is safe against
+ * public HTTPS endpoints.
+ */
+function requestOverH2(
+  url: string,
+  init: StreamToolInit,
+): Promise<StreamToolResponse> {
+  const target = new URL(url);
+  const session = connect(target.origin);
+
+  const h2Headers: Record<string, string> = {
+    ":method": (init.method ?? "POST").toUpperCase(),
+    ":path": `${target.pathname}${target.search}`,
+  };
+  // HTTP/2 requires lowercase header names; `Headers` normalizes any HeadersInit.
+  new Headers(init.headers).forEach((value, key) => {
+    h2Headers[key] = value;
+  });
+
+  const req = session.request(h2Headers, { endStream: false });
+  req.setEncoding("utf8");
+
+  // Collect the response as it arrives so no frame is lost between the `response`
+  // event and the route calling `text()`. Resolve-only (never rejects) so an
+  // unread body on a failed request cannot raise an unhandled rejection; a
+  // stream error is surfaced through `text()` instead.
+  let responseBody = "";
+  let streamError: Error | null = null;
+  const bodyEnded = new Promise<void>((resolve) => {
+    req.on("data", (chunk: string) => {
+      responseBody += chunk;
+    });
+    req.on("end", () => resolve());
+    req.on("error", (err: Error) => {
+      streamError = err;
+      resolve();
+    });
+  });
+
+  void pumpRequestBody(init.body, req);
+
+  return new Promise<StreamToolResponse>((resolve, reject) => {
+    const fail = (err: Error) => {
+      session.close();
+      reject(err);
+    };
+    req.on("response", (headers) => {
+      const status = Number(headers[":status"]);
+      resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => {
+          await bodyEnded;
+          session.close();
+          if (streamError) throw streamError;
+          return responseBody;
+        },
+      });
+    });
+    req.on("error", fail);
+    session.on("error", fail);
+  });
+}
+
+/**
+ * `fetch`-shaped client for the `/stream-tool` bridge, forced over HTTP/2 on
+ * HTTPS endpoints.
+ *
+ * `/stream-tool` streams the request body (the LLM's tool-call deltas) while the
+ * AI server streams the response back, full-duplex over one connection. Over
+ * HTTP/1.1 a reverse proxy (Traefik, and Go's `net/http` in general) drains the
+ * request body once the response starts, truncating the upload before the final
+ * message arrives. HTTP/2 carries the request and response as independent
+ * streams, so the duplex survives the proxy.
+ *
+ * HTTPS targets go over HTTP/2 via the stable `node:http2` client — no extra
+ * dependency and no experimental flag. Plain-HTTP targets (local dev, no proxy
+ * in the path) fall back to the built-in `fetch`, where HTTP/1.1 duplex is
+ * already safe.
+ *
+ * Use this only for `/stream-tool`; other toolkit calls are plain
+ * request/response and can use the default `fetch`.
+ *
+ * @param url - The `/stream-tool` endpoint URL.
+ * @param init - Fetch init with the streaming `body` and `duplex: "half"`.
+ * @returns The upstream response, exposing `ok`, `status`, and `text()`.
+ */
+export async function streamToolFetch(
+  url: string,
+  init: StreamToolInit,
+): Promise<StreamToolResponse> {
+  const target = new URL(url);
+  if (target.protocol !== "https:") {
+    const res = await fetch(url, init as RequestInit);
+    return { ok: res.ok, status: res.status, text: () => res.text() };
+  }
+  return requestOverH2(url, init);
+}

--- a/src/lib/use-stream-tool-editor.ts
+++ b/src/lib/use-stream-tool-editor.ts
@@ -1,0 +1,139 @@
+"use client";
+
+import type { AnyExtension } from "@tiptap/core";
+import { Collaboration } from "@tiptap/extension-collaboration";
+import { CollaborationCaret } from "@tiptap/extension-collaboration-caret";
+import { useEditor } from "@tiptap/react";
+import { ServerAiToolkit } from "@tiptap/server-ai-toolkit";
+import { TiptapCollabProvider } from "@tiptap-pro/provider";
+import { useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
+import * as Y from "yjs";
+import { getCollabConfig } from "@/app/server-ai-agent-chatbot/actions";
+
+type UseStreamToolEditorOptions = {
+  /** Slug used to build the collaborative document id. */
+  slug: string;
+  /** HTML content applied to the document on first connect. */
+  initialContent: string;
+  /** Content extensions placed before the collaboration baseline (StarterKit, Table, ...). */
+  extensions: AnyExtension[];
+  /** Extensions placed after ServerAiToolkit (e.g. TrackedChanges). */
+  trailingExtensions?: AnyExtension[];
+};
+
+/**
+ * Shared editor + collaboration wiring for the server stream-tool demos. Owns
+ * the Y.Doc, the TiptapCollabProvider lifecycle, and the editor (with a shared
+ * Collaboration / CollaborationCaret / ServerAiToolkit baseline plus the
+ * caller's demo-specific extensions). Streamed edits arrive via Y.Doc sync.
+ */
+export function useStreamToolEditor({
+  slug,
+  initialContent,
+  extensions,
+  trailingExtensions = [],
+}: UseStreamToolEditorOptions) {
+  const [doc] = useState(() => new Y.Doc());
+  const [documentId] = useState(() => `${slug}/${uuid()}`);
+  const [provider, setProvider] = useState<TiptapCollabProvider | null>(null);
+
+  const editor = useEditor(
+    {
+      immediatelyRender: false,
+      extensions: [
+        ...extensions,
+        Collaboration.configure({ document: doc }),
+        ...(provider
+          ? [
+              CollaborationCaret.configure({
+                provider,
+                user: { name: "You", color: "#0EA5E9" },
+                // Inline-styled caret so the demo doesn't depend on the
+                // extension's stylesheet shipping with the demo build.
+                render: (user) => {
+                  const cursor = document.createElement("span");
+                  cursor.style.cssText = `
+                    border-left: 2px solid ${user.color};
+                    border-right: 2px solid ${user.color};
+                    margin-left: -1px;
+                    margin-right: -1px;
+                    pointer-events: none;
+                    position: relative;
+                    word-break: normal;
+                    height: 1em;
+                    display: inline-block;
+                    vertical-align: text-bottom;
+                  `;
+                  const label = document.createElement("div");
+                  label.style.cssText = `
+                    background-color: ${user.color};
+                    border-radius: 3px 3px 3px 0;
+                    color: white;
+                    font-size: 12px;
+                    font-weight: 600;
+                    left: -2px;
+                    line-height: normal;
+                    padding: 1px 4px;
+                    position: absolute;
+                    top: -1.4em;
+                    user-select: none;
+                    white-space: nowrap;
+                  `;
+                  label.textContent = user.name as string;
+                  cursor.appendChild(label);
+                  return cursor;
+                },
+              }),
+            ]
+          : []),
+        ServerAiToolkit,
+        ...trailingExtensions,
+      ],
+    },
+    [provider],
+  );
+
+  // Capture the editor in a ref so the provider effect doesn't tear down the
+  // websocket each time the editor recreates after `provider` changes.
+  const editorRef = useRef(editor);
+  editorRef.current = editor;
+
+  useEffect(() => {
+    let cancelled = false;
+    let createdProvider: TiptapCollabProvider | null = null;
+
+    const setupProvider = async () => {
+      try {
+        const { token, appId, collabBaseUrl } = await getCollabConfig(
+          "user-1",
+          documentId,
+        );
+        if (cancelled) return;
+        createdProvider = new TiptapCollabProvider({
+          ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
+          name: documentId,
+          token,
+          document: doc,
+          user: "user-1",
+          onConnect() {
+            editorRef.current?.commands.setContent(initialContent);
+          },
+        });
+        setProvider(createdProvider);
+      } catch (error) {
+        console.error("Failed to setup collaboration:", error);
+      }
+    };
+
+    setupProvider();
+
+    return () => {
+      cancelled = true;
+      createdProvider?.destroy();
+      setProvider(null);
+    };
+  }, [documentId, doc, initialContent]);
+
+  return { editor, documentId };
+}


### PR DESCRIPTION
## What

Adds two server-side streaming demos that drive the AI server's `/stream-tool` endpoint from a Next.js route:

- **Server Stream Tool** (`/server-ai-stream-tool-chatbot`): an LLM streams a `tiptapEdit` tool call and the editor types the edit live via Y.Doc sync.
- **Server Stream Tool (Tracked Changes)** (`/server-ai-stream-tool-chatbot-tracked-changes`): the same flow in tracked-changes mode, so the edit arrives as an accept/reject suggestion.

## Why HTTP/2

`/stream-tool` is full-duplex over one POST: the client streams the request body (the model's tool-call deltas) while the server streams the response back at the same time. Over HTTP/1.1, a Go-based reverse proxy (Traefik) drains the request body once the response starts, which truncates the upload before the final message and corrupts the stream (`incomplete_stream`).

`streamToolFetch` sends the request over HTTP/2 (Node's stable `node:http2` client) on HTTPS targets, where the request and response are independent streams, so the duplex survives the proxy. It falls back to the built-in `fetch` for plain-HTTP local dev. The fix is entirely client-side, no AI server or infra change is required.

## Verification

Verified against staging: over HTTP/1.1 the stream truncates (`incomplete_stream`); over HTTP/2 it completes with full duplex preserved and the document intact.