### PR TITLE
fix: refresh collab JWT on reconnect to stop permission-denied loop

### DIFF
--- a/src/app/server-ai-agent-chatbot/page.tsx
+++ b/src/app/server-ai-agent-chatbot/page.tsx
@@ -37,7 +37,7 @@ export default function Page() {
   useEffect(() => {
     const setupProvider = async () => {
       try {
-        const { token, appId, collabBaseUrl } = await getCollabConfig(
+        const { appId, collabBaseUrl } = await getCollabConfig(
           "user-1",
           documentId,
         );
@@ -45,7 +45,11 @@ export default function Page() {
         const collabProvider = new TiptapCollabProvider({
           ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
           name: documentId,
-          token,
+          // Pass the token as a function so the provider mints a fresh JWT on
+          // every reconnect; a static string freezes at its 30-min expiry and
+          // loops on permission-denied after a reconnect.
+          token: async () =>
+            (await getCollabConfig("user-1", documentId)).token,
           document: doc,
           user: "user-1",
           onOpen() {

--- a/src/app/server-comments/page.tsx
+++ b/src/app/server-comments/page.tsx
@@ -49,7 +49,7 @@ export default function Page() {
 
     const setupProvider = async () => {
       try {
-        const { token, appId, collabBaseUrl } = await getCollabConfig(
+        const { appId, collabBaseUrl } = await getCollabConfig(
           "user-1",
           documentId,
         );
@@ -57,7 +57,11 @@ export default function Page() {
         collabProvider = new TiptapCollabProvider({
           ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
           name: documentId,
-          token,
+          // Pass the token as a function so the provider mints a fresh JWT on
+          // every reconnect; a static string freezes at its 30-min expiry and
+          // loops on permission-denied after a reconnect.
+          token: async () =>
+            (await getCollabConfig("user-1", documentId)).token,
           document: doc,
           user: "user-1",
           onOpen() {

--- a/src/lib/use-stream-tool-editor.ts
+++ b/src/lib/use-stream-tool-editor.ts
@@ -105,7 +105,7 @@ export function useStreamToolEditor({
 
     const setupProvider = async () => {
       try {
-        const { token, appId, collabBaseUrl } = await getCollabConfig(
+        const { appId, collabBaseUrl } = await getCollabConfig(
           "user-1",
           documentId,
         );
@@ -113,7 +113,11 @@ export function useStreamToolEditor({
         createdProvider = new TiptapCollabProvider({
           ...(collabBaseUrl ? { baseUrl: collabBaseUrl } : { appId }),
           name: documentId,
-          token,
+          // Pass the token as a function so the provider mints a fresh JWT on
+          // every reconnect; a static string freezes at its 30-min expiry and
+          // loops on permission-denied after a reconnect.
+          token: async () =>
+            (await getCollabConfig("user-1", documentId)).token,
           document: doc,
           user: "user-1",
           onConnect() {


### PR DESCRIPTION
The collab provider got the JWT as a static string, so it re-sent the same token on every reconnect. Once the 30-min token expired, reconnects looped on `permission-denied` — spamming the browser console and the Tiptap Cloud auth logs (`token-expired`, with a frozen iat/exp).

HocuspocusProvider only refreshes the token when it's a function, so `token` now returns a fresh JWT per reconnect.

Touches `server-ai-agent-chatbot`, `server-comments` and `use-stream-tool-editor`.