### PR TITLE
feat: send the { type, id } document object to stream-tool

### DIFF
--- a/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
@@ -257,7 +257,7 @@ export async function POST(req: Request) {
             version: 1,
             type: "start",
             editorContext: schemaAwarenessData,
-            document: documentId,
+            document: { type: "cloud", id: documentId },
             tool: { name: "tiptapEdit" },
             user: userId ?? "ai-assistant",
             // Tracked-changes mode: the AI server keeps the old content as a

--- a/src/app/api/server-ai-stream-tool-chatbot/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot/route.ts
@@ -257,7 +257,7 @@ export async function POST(req: Request) {
             version: 1,
             type: "start",
             editorContext: schemaAwarenessData,
-            document: documentId,
+            document: { type: "cloud", id: documentId },
             tool: { name: "tiptapEdit" },
             user: userId ?? "ai-assistant",
           });


### PR DESCRIPTION
The `stream-tool` API now takes `document` as a `{ type: 'cloud', id }` object instead of a plain id string, matching `execute-tool`. Both server stream-tool demo routes now send the new shape.

The backend change is already in production, so the demos need this to keep working.