### PR TITLE
Update AI model to gpt-5.6-luna

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/comments-workflow/route.ts
+++ b/src/app/api/comments-workflow/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
   const workflow = createEditThreadsWorkflow();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/insert-content-workflow/route.ts
+++ b/src/app/api/insert-content-workflow/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
   const workflow = createInsertContentWorkflow();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });
@@ -40,8 +40,6 @@ export async function POST(req: Request) {
       task,
       replace,
     }),
-    // If you use gpt-5.4-nano, set the reasoning effort to low to improve the
-    // response time.
     providerOptions: {
       openai: {
         reasoningEffort: "low",

--- a/src/app/api/justified-changes/route.ts
+++ b/src/app/api/justified-changes/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/multi-document/route.ts
+++ b/src/app/api/multi-document/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/proofreader/route.ts
+++ b/src/app/api/proofreader/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
   });
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
       task: "Correct all grammar and spelling mistakes",
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
-    // If you use gpt-5.4-nano, set the reasoning effort to low to improve the
+    // If you use gpt-5.6-luna, set the reasoning effort to low to improve the
     // response time.
     providerOptions: {
       openai: {

--- a/src/app/api/schema-awareness/route.ts
+++ b/src/app/api/schema-awareness/route.ts
@@ -31,7 +31,7 @@ export async function POST(req: Request) {
   }: { messages: UIMessage[]; schemaAwareness: string } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/selection-awareness/route.ts
+++ b/src/app/api/selection-awareness/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-ai-agent-chatbot/route.ts
+++ b/src/app/api/server-ai-agent-chatbot/route.ts
@@ -76,7 +76,7 @@ export async function POST(req: Request) {
   );
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
@@ -228,7 +228,7 @@ export async function POST(req: Request) {
   //    callback yields raw text deltas as the model generates them —
   //    which is what `/stream-tool` expects.
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-ai-stream-tool-chatbot/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot/route.ts
@@ -228,7 +228,7 @@ export async function POST(req: Request) {
   //    callback yields raw text deltas as the model generates them —
   //    which is what `/stream-tool` expects.
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-ai-tracked-changes/route.ts
+++ b/src/app/api/server-ai-tracked-changes/route.ts
@@ -81,7 +81,7 @@ export async function POST(req: Request) {
   );
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-comments/route.ts
+++ b/src/app/api/server-comments/route.ts
@@ -75,7 +75,7 @@ export async function POST(req: Request) {
   );
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/server-read-selection/route.ts
+++ b/src/app/api/server-read-selection/route.ts
@@ -67,7 +67,7 @@ export async function POST(req: Request) {
   );
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/split-view/route.ts
+++ b/src/app/api/split-view/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/template-workflow/route.ts
+++ b/src/app/api/template-workflow/route.ts
@@ -26,7 +26,7 @@ export async function POST(req: Request) {
   const workflow = createTemplateWorkflow({ htmlTemplate });
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/tiptap-edit-workflow/route.ts
+++ b/src/app/api/tiptap-edit-workflow/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
   const workflow = createTiptapEditWorkflow();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });
@@ -40,8 +40,6 @@ export async function POST(req: Request) {
       task,
     }),
     output: Output.object({ schema: workflow.zodOutputSchema }),
-    // If you use gpt-5.4-nano, set the reasoning effort to low to improve the
-    // response time.
     providerOptions: {
       openai: {
         reasoningEffort: "low",

--- a/src/app/api/tool-streaming/route.ts
+++ b/src/app/api/tool-streaming/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-nano"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/tracked-changes-comments/route.ts
+++ b/src/app/api/tracked-changes-comments/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });

--- a/src/app/api/tracked-changes/route.ts
+++ b/src/app/api/tracked-changes/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const model = wrapLanguageModel({
-    model: gateway("openai/gpt-5.4-mini"),
+    model: gateway("openai/gpt-5.6-luna"),
     middleware:
       process.env.NODE_ENV === "production" ? [] : devToolsMiddleware(),
   });


### PR DESCRIPTION
Update the AI model used in all demos. With the recent price drop in GPT-5.6-luna, it now becomes less expensive than GPT-5.4-mini, and more intelligent, so it makes sense to replace GPT-5.4-mini with GPT-5.6-luna.

This pull request also removes a couple of old, redundant comments that were written for GPT-5 and do not make sense anymore. 