### PR TITLE
Show tracked block splits in the server tracked changes demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@tiptap-pro/client-ai-toolkit-ai-sdk": "0.13.0",
     "@tiptap-pro/client-ai-toolkit-tool-definitions": "0.13.0",
     "@tiptap-pro/extension-comments": "^3.8.4",
-    "@tiptap-pro/extension-tracked-changes": "0.11.1",
+    "@tiptap-pro/extension-tracked-changes": "0.12.1",
     "@tiptap-pro/provider": "^3.8.4",
     "@tiptap/ai-toolkit": "0.3.0",
     "@tiptap/core": "3.22.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^3.8.4
         version: 3.8.4(@hocuspocus/provider@3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@hocuspocus/transformer@3.4.3(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)(y-prosemirror@1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30))(@tiptap-pro/provider@3.8.4(@hocuspocus/provider@3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(lib0@0.2.117)(yjs@13.6.30))(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap-pro/extension-tracked-changes':
-        specifier: 0.11.1
-        version: 0.11.1(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
+        specifier: 0.12.1
+        version: 0.12.1(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)
       '@tiptap-pro/provider':
         specifier: ^3.8.4
         version: 3.8.4(@hocuspocus/provider@3.4.4(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(lib0@0.2.117)(yjs@13.6.30)
@@ -727,8 +727,8 @@ packages:
       '@tiptap/core': ^3.15.0
       '@tiptap/pm': ^3.15.0
 
-  '@tiptap-pro/extension-tracked-changes@0.11.1':
-    resolution: {integrity: sha512-levGmBQJutMOoxH+8yesOFCm55odGCaSf4JkVLmlYTAO6h+XA5kf7j/rca80puE/hGno+40idoNSOsO6rkJMww==}
+  '@tiptap-pro/extension-tracked-changes@0.12.1':
+    resolution: {integrity: sha512-fM2FL9gd51QPYXWv3KZgPkvGZvn2r2CQDvFbIW1FAuPKq2XQhOGHZ9Iv+swm7rgGdpxQKSJPe8/n0smtKMHzwg==}
     peerDependencies:
       '@tiptap/core': ^3.15.0
       '@tiptap/pm': ^3.15.0
@@ -1918,7 +1918,7 @@ snapshots:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5
 
-  '@tiptap-pro/extension-tracked-changes@0.11.1(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
+  '@tiptap-pro/extension-tracked-changes@0.12.1(@tiptap/core@3.22.5(@tiptap/pm@3.22.5))(@tiptap/pm@3.22.5)':
     dependencies:
       '@tiptap/core': 3.22.5(@tiptap/pm@3.22.5)
       '@tiptap/pm': 3.22.5

--- a/src/demos/server-ai-tracked-changes/suggestion-utils.ts
+++ b/src/demos/server-ai-tracked-changes/suggestion-utils.ts
@@ -45,21 +45,18 @@ export function getSuggestionNodeLabels(suggestion: Suggestion) {
   return [...new Set(types)];
 }
 
+const SUGGESTION_PREFIXES: Record<Suggestion["type"], string> = {
+  add: "+",
+  delete: "-",
+  replace: "↔",
+  markChange: "◊",
+  sink: "⇥",
+  lift: "⇤",
+  split: "¶",
+};
+
 export function getSuggestionPreview(suggestion: Suggestion) {
-  const prefix =
-    suggestion.type === "add"
-      ? "+"
-      : suggestion.type === "delete"
-        ? "-"
-        : suggestion.type === "replace"
-          ? "↔"
-          : suggestion.type === "markChange"
-            ? "◊"
-            : suggestion.type === "sink"
-              ? "⇥"
-              : suggestion.type === "lift"
-                ? "⇤"
-                : "~";
+  const prefix = SUGGESTION_PREFIXES[suggestion.type] ?? "~";
 
   if (
     suggestion.type === "markChange" &&
@@ -82,6 +79,13 @@ export function getSuggestionPreview(suggestion: Suggestion) {
 
   if (suggestion.type === "lift") {
     return `${prefix} outdent "${suggestion.text}"`;
+  }
+
+  // A split's text is the block that starts after the break, empty when Enter ends a block.
+  if (suggestion.type === "split") {
+    return suggestion.text
+      ? `${prefix} split before "${suggestion.text}"`
+      : `${prefix} split into a new block`;
   }
 
   const insertedPreview = buildNodesPreview(

--- a/src/demos/server-ai-tracked-changes/tracked-changes-panel.tsx
+++ b/src/demos/server-ai-tracked-changes/tracked-changes-panel.tsx
@@ -32,6 +32,9 @@ function suggestionAccent(type: string) {
   if (type === "lift") {
     return "border-l-violet-500";
   }
+  if (type === "split") {
+    return "border-l-sky-500";
+  }
   return "border-l-blue-500";
 }
 

--- a/src/styles/tracked-changes.css
+++ b/src/styles/tracked-changes.css
@@ -115,6 +115,14 @@
   box-shadow: inset 2px 0 0 oklch(55% 0.2 290);
 }
 
+/* Block split. The content did not change, so only the ¶ widget is styled, never the block. */
+.tiptap .tiptap-tracked-change-split-marker {
+  color: oklch(62.3% 0.214 259.8);
+  margin-left: 0.15em;
+  opacity: 0.7;
+  user-select: none;
+}
+
 :where(
     .tracked-changes-comments-demo
       .tiptap


### PR DESCRIPTION
Bumps the Tracked Changes extension to 0.12.1, where pressing Enter tracks only the paragraph break instead of duplicating the split text.

The suggestion panel labels the new split type and gives it its own accent, so a split no longer falls through to the unknown-type fallback.

The ¶ marker the extension renders at the break is styled, matching the Tracked Changes demos.

The split block itself is left unstyled, since its content did not change.

Pairs with the ai-server merge request that stops AI edits from erasing pending splits.
