### PR TITLE
fix: disable constrained sampling in the stream-tool demos

### DIFF
--- a/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot-tracked-changes/route.ts
@@ -245,13 +245,9 @@ export async function POST(req: Request) {
         inputSchema: z.fromJSONSchema(
           tiptapEditTool.inputSchema as z.core.JSONSchema.JSONSchema,
         ),
-        // Force OpenAI structured-outputs constrained sampling so the
-        // `inputSchema` enum on `content[].type` is enforced at token level
-        // (not just sent as a hint). Without this flag, the LLM has been
-        // observed bypassing the enum and nesting operations into content.
-        // See `@ai-sdk/openai`'s `prepareChatTools` — `strict` is only
-        // forwarded when explicitly set; OpenAI defaults to false otherwise.
-        strict: true,
+        // `content` accepts arbitrary ProseMirror JSON, so the generated schema
+        // is recursive and OpenAI structured outputs rejects it with a 400.
+        strict: false,
         onInputStart: () => {
           if (forwardedStart) return;
           forwardedStart = true;

--- a/src/app/api/server-ai-stream-tool-chatbot/route.ts
+++ b/src/app/api/server-ai-stream-tool-chatbot/route.ts
@@ -245,13 +245,9 @@ export async function POST(req: Request) {
         inputSchema: z.fromJSONSchema(
           tiptapEditTool.inputSchema as z.core.JSONSchema.JSONSchema,
         ),
-        // Force OpenAI structured-outputs constrained sampling so the
-        // `inputSchema` enum on `content[].type` is enforced at token level
-        // (not just sent as a hint). Without this flag, the LLM has been
-        // observed bypassing the enum and nesting operations into content.
-        // See `@ai-sdk/openai`'s `prepareChatTools` — `strict` is only
-        // forwarded when explicitly set; OpenAI defaults to false otherwise.
-        strict: true,
+        // `content` accepts arbitrary ProseMirror JSON, so the generated schema
+        // is recursive and OpenAI structured outputs rejects it with a 400.
+        strict: false,
         onInputStart: () => {
           if (forwardedStart) return;
           forwardedStart = true;


### PR DESCRIPTION
`strict: true` makes the provider reject the `tiptapEdit` tool schema with a 400, so both stream-tool demos fail on every request.

`tiptapEdit`'s `content` accepts arbitrary ProseMirror JSON, so its schema is recursive and cannot satisfy OpenAI structured outputs. The other server demos never set `strict` and work fine.

Tested locally: the 400 is gone and the demos stream again.